### PR TITLE
fix: use consistent object-form model config in claude-only example

### DIFF
--- a/examples/claude-only/openclaw.json
+++ b/examples/claude-only/openclaw.json
@@ -9,7 +9,9 @@
       {
         "id": "main",
         "default": true,
-        "model": "anthropic/claude-opus-4-6",
+        "model": {
+          "primary": "anthropic/claude-opus-4-6"
+        },
         "workspace": "~/.openclaw/workspace"
       }
     ]


### PR DESCRIPTION
## Problem

The `claude-only/openclaw.json` example uses **string form** for the main agent's model config:

```json
"model": "anthropic/claude-opus-4-6"
```

While **all other examples** (claude-codex, claude-gemini, full-stack) and the `defaults` block in this same file use **object form**:

```json
"model": { "primary": "anthropic/claude-opus-4-6" }
```

## Why It Matters

OpenClaw treats these two forms differently:

| Form | Behavior |
|------|----------|
| String: `"model": "X"` | **Inherits** global fallbacks automatically |
| Object: `"model": { "primary": "X" }` | **Replaces** global fallbacks entirely |

This behavioral difference is documented in:
- [`examples/README.md`](examples/README.md) → "Per-Agent Fallback Behavior"
- [`references/provider-config.md`](references/provider-config.md) → "Per-Agent Fallback Behavior"

The `claude-only` config is the simplest example and the one most likely to be copied by new users as a starting point. When those users later add a second provider, they'll copy the string-form pattern and silently lose fallback coverage.

## Impact

For claude-only with a single provider: **zero runtime impact** (no fallbacks to inherit or lose).

The fix is purely about **consistency and preventing copy-paste errors** as users scale up their setup.

## Change

```diff
- "model": "anthropic/claude-opus-4-6",
+ "model": {
+   "primary": "anthropic/claude-opus-4-6"
+ },
```