### PR TITLE
fix: register k2-thinking model referenced in kimi-orchestrator fallback chain

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -111,6 +111,25 @@
         "tau2": 0.959
       },
       "estimated": false
+    },
+    "k2-thinking": {
+      "provider": "kimi-coding",
+      "openclaw_id": "kimi-coding/k2-thinking",
+      "tier": null,
+      "speed_tok_s": null,
+      "ttft_s": null,
+      "intelligence": null,
+      "context_window": 131072,
+      "best_at": ["extended reasoning", "complex problem solving"],
+      "benchmarks": {
+        "ifbench": null,
+        "gpqa": null,
+        "coding": null,
+        "math": null,
+        "tau2": null
+      },
+      "estimated": false,
+      "notes": "Used as fallback for kimi-orchestrator only. Benchmarks not yet available on Artificial Analysis. Context window from Kimi platform docs (256K advertised, 131072 used conservatively to match K2.5 config)."
     }
   },
   "tiers": {

--- a/examples/full-stack/openclaw.json
+++ b/examples/full-stack/openclaw.json
@@ -10,7 +10,7 @@
       "kimi-coding": {
         "baseUrl": "https://api.kimi.com/coding/v1",
         "api": "openai-completions",
-        "models": [{ "id": "k2p5" }]
+        "models": [{ "id": "k2p5" }, { "id": "k2-thinking" }]
       }
     }
   },


### PR DESCRIPTION
## Problem

The `kimi-orchestrator` agent in `examples/full-stack/openclaw.json` references `kimi-coding/k2-thinking` as its first fallback:

```json
"fallbacks": [
  "kimi-coding/k2-thinking",     // ← not registered anywhere
  "google-gemini-cli/gemini-3-pro-preview",
  "anthropic/claude-opus-4-6"
]
```

But `k2-thinking` is never defined:
- ❌ Not in `kimi-coding` provider's model list (`full-stack/openclaw.json`)
- ❌ Not in `benchmarks.json`
- ❌ Not mentioned in `SKILL.md`

## Impact

OpenClaw can't resolve an unregistered model. The fallback **silently fails** — kimi-orchestrator skips directly to its second fallback (Gemini Pro) whenever K2.5 is unavailable. No error surfaced to the user, just unexpected routing behavior.

## Verification

Kimi K2 Thinking is a real model:
- [Kimi Platform docs](https://platform.moonshot.ai/docs/guide/use-kimi-k2-thinking-model)
- [HuggingFace: moonshotai/Kimi-K2-Thinking](https://huggingface.co/moonshotai/Kimi-K2-Thinking)
- [OpenRouter listing](https://openrouter.ai/moonshotai/kimi-k2-thinking)

It uses extended reasoning (chain-of-thought) before responding, making it a sensible same-provider fallback for the orchestration tier.

## Changes

1. **`examples/full-stack/openclaw.json`** — Added `k2-thinking` to `kimi-coding` provider model list
2. **`benchmarks.json`** — Added `k2-thinking` entry with null benchmark scores and a `notes` field explaining the data gap

## Trade-off

Adding a model with null benchmarks means the routing algorithm can't make data-driven decisions about it. However, as a **fallback** (not a primary routing target), this is acceptable:
- It only activates when K2.5 is unavailable
- Same-provider fallback (K2.5 → K2 Thinking) is useful for model-specific issues that don't affect the Kimi provider itself
- Benchmark data can be backfilled when Artificial Analysis lists it