### PR TITLE
fix: add benchmark scale metadata to disambiguate mixed units in benchmarks.json

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -3,6 +3,13 @@
   "source": "Artificial Analysis API v4",
   "date": "2026-02-15",
   "notes": "Codex scores marked 'estimated: true' are from OpenAI blog data, not independently verified.",
+  "benchmark_scales": {
+    "ifbench": { "scale": "0-1", "description": "Instruction Following Benchmark. Higher = better instruction compliance." },
+    "gpqa": { "scale": "0-1", "description": "Graduate-level science QA. Higher = better scientific reasoning." },
+    "coding": { "scale": "0-100", "unit": "percent", "description": "SWE-bench Verified. Percentage of real GitHub issues resolved." },
+    "math": { "scale": "0-1", "description": "AIME 2025 normalized score. Higher = better mathematical reasoning." },
+    "tau2": { "scale": "0-1", "description": "TAU-bench v2 (agentic tool use). Higher = better multi-step tool orchestration." }
+  },
   "models": {
     "gemini-2.5-flash-lite": {
       "provider": "google-gemini-cli",


### PR DESCRIPTION
## Problem

`benchmarks.json` uses **two different numeric scales** with no indication of which is which:

| Benchmark | Scale | Example Values |
|-----------|-------|---------------|
| `coding` (SWE-bench) | **0–100** (percentage) | Codex: 49.3, Opus: 43.3, Pro: 35.1 |
| `ifbench` | **0–1** (normalized) | Flash: 0.780, Opus: 0.639 |
| `gpqa` | **0–1** (normalized) | Pro: 0.908, Opus: 0.769 |
| `math` | **0–1** (normalized) | Codex: 0.990, Flash: 0.970 |
| `tau2` | **0–1** (normalized) | K2.5: 0.959, Codex: 0.811 |

This is further confused in `SKILL.md` and `README.md` where math scores display as "99.0" and "97.0" (×100 for readability) while the JSON stores 0.990 and 0.970.

## Impact

Anyone building on top of `benchmarks.json` — validation scripts, comparison tools, routing optimizers, or even an agent interpreting the data — would need to **reverse-engineer which scale each benchmark uses**. A naive comparison (`coding: 49.3` vs `math: 0.990`) suggests coding scores are ~50× higher than math scores, which is obviously wrong.

## Change

Adds a top-level `benchmark_scales` object:

```json
"benchmark_scales": {
  "ifbench": { "scale": "0-1", "description": "Instruction Following Benchmark..." },
  "gpqa":    { "scale": "0-1", "description": "Graduate-level science QA..." },
  "coding":  { "scale": "0-100", "unit": "percent", "description": "SWE-bench Verified..." },
  "math":    { "scale": "0-1", "description": "AIME 2025 normalized score..." },
  "tau2":    { "scale": "0-1", "description": "TAU-bench v2 (agentic tool use)..." }
}
```

**No model data is changed** — this is purely additive metadata. Fully backwards-compatible with any existing code that reads `benchmarks.json`.

## Alternative Considered

Normalizing all scores to the same scale (0–1 or 0–100) was considered but rejected:
- Changing existing values would break any tooling already consuming this file
- SWE-bench is universally reported as a percentage in the ML community; converting to 0–1 would confuse readers who compare against external sources
- The metadata approach preserves original values while making the scales explicit