### PR TITLE
fix: correct Codex context window (266K) and default fallback order

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Every agent must have fallbacks spanning **multiple providers**. Same-provider f
 
 | Agent | Primary | Fallback 1 | Fallback 2 | Fallback 3 |
 |-------|---------|------------|------------|------------|
-| main | Opus (Anthropic) | Pro (Google) | Codex (OpenAI) | K2.5 (Kimi) |
+| main | Opus (Anthropic) | Codex (OpenAI) | Pro (Google) | K2.5 (Kimi) |
 | codex | Codex (OpenAI) | Opus (Anthropic) | Pro (Google) | K2.5 (Kimi) |
 | gemini-researcher | Pro (Google) | Flash (Google) | Opus (Anthropic) | Codex (OpenAI) |
 | gemini-fast | Flash (Google) | Pro (Google) | Opus (Anthropic) | Codex (OpenAI) |

--- a/SKILL.md
+++ b/SKILL.md
@@ -43,7 +43,7 @@ For full provider configuration details, consult `references/provider-config.md`
 | SIMPLE | Gemini 2.5 Flash-Lite | `google-gemini-cli/gemini-2.5-flash-lite` | 495 tok/s | 0.23s | 21.6 | 1M | Low-latency pings, trivial format tasks |
 | FAST | Gemini 3 Flash | `google-gemini-cli/gemini-3-flash-preview` | 206 tok/s | 12.75s | 46.4 | 1M | Instruction following, structured output, heartbeats |
 | RESEARCH | Gemini 3 Pro | `google-gemini-cli/gemini-3-pro-preview` | 131 tok/s | 29.59s | 48.4 | 1M | Scientific research, long context analysis |
-| CODE | GPT-5.3 Codex | `openai-codex/gpt-5.3-codex` | 113 tok/s | 20.00s | 51.5 | 200K | Code generation, math (99.0) |
+| CODE | GPT-5.3 Codex | `openai-codex/gpt-5.3-codex` | 113 tok/s | 20.00s | 51.5 | 266K | Code generation, math (99.0) |
 | DEEP | Claude Opus 4.6 | `anthropic/claude-opus-4-6` | 67 tok/s | 1.76s | 53.0 | 200K | Reasoning, planning, judgment |
 | ORCHESTRATE | Kimi K2.5 | `kimi-coding/k2p5` | 39 tok/s | 1.65s | 46.7 | 128K | Multi-agent orchestration (TAU-2: 0.959) |
 
@@ -219,7 +219,7 @@ When a model is unavailable or rate-limited, fall through in reliability order.
 ### Full Stack (4 providers)
 | Task Type | Primary | Fallback 1 | Fallback 2 | Fallback 3 |
 |-----------|---------|------------|------------|------------|
-| Reasoning | Opus | Gemini Pro | Codex | Kimi K2.5 |
+| Reasoning | Opus | Codex | Gemini Pro | Kimi K2.5 |
 | Code | Codex | Opus | Gemini Pro | Kimi K2.5 |
 | Research | Gemini Pro | Opus | Codex | Kimi K2.5 |
 | Fast tasks | Flash-Lite | Flash | Opus | Codex |

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -72,7 +72,7 @@
       "speed_tok_s": 113,
       "ttft_s": 20.00,
       "intelligence": 51.5,
-      "context_window": 200000,
+      "context_window": 266000,
       "best_at": ["code generation", "math", "debugging"],
       "benchmarks": {
         "ifbench": 0.590,

--- a/examples/full-stack/openclaw.json
+++ b/examples/full-stack/openclaw.json
@@ -19,8 +19,8 @@
       "model": {
         "primary": "anthropic/claude-opus-4-6",
         "fallbacks": [
-          "google-gemini-cli/gemini-3-pro-preview",
           "openai-codex/gpt-5.3-codex",
+          "google-gemini-cli/gemini-3-pro-preview",
           "kimi-coding/k2p5"
         ]
       },
@@ -35,8 +35,8 @@
         "model": {
           "primary": "anthropic/claude-opus-4-6",
           "fallbacks": [
-            "google-gemini-cli/gemini-3-pro-preview",
             "openai-codex/gpt-5.3-codex",
+            "google-gemini-cli/gemini-3-pro-preview",
             "kimi-coding/k2p5"
           ]
         },

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -13,8 +13,8 @@ To use routing, agents must be defined in `openclaw.json`. Here is the recommend
       "model": {
         "primary": "anthropic/claude-opus-4-6",
         "fallbacks": [
-          "google-gemini-cli/gemini-3-pro-preview",
           "openai-codex/gpt-5.3-codex",
+          "google-gemini-cli/gemini-3-pro-preview",
           "kimi-coding/k2p5"
         ]
       },


### PR DESCRIPTION
## Changes

### Codex context window: 200K → 266K
The Codex 5.3 context window was listed as 200,000 tokens across benchmarks.json and SKILL.md. The actual value is 266,000 tokens (per OpenAI docs and confirmed in production configs).

Updated in:
- `benchmarks.json` — `context_window` field
- `SKILL.md` — model tier table

### Default fallback order: Codex before Pro
The default fallback chain was Opus → Pro → Codex → Kimi. Reordered to Opus → Codex → Pro → Kimi.

**Rationale:** Codex has a higher Intelligence score (51.5) than Pro (48.4), making it a better general-purpose fallback. Pro is a specialist (GPQA 0.908, 1M context) — great when you specifically need research or long context, but Codex is the safer all-rounder when Opus is unavailable.

Updated in:
- `examples/full-stack/openclaw.json` — defaults and main agent
- `references/provider-config.md` — reference config block
- `SKILL.md` — Full Stack fallback table
- `README.md` — Cross-Provider Fallback Chains table

## Impact
No behavioral change for users with custom fallback chains. Only affects the default/example configs.