### PR TITLE
feat(router): add auth profile overrides for inventory routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [3.4.0] — 2026-04-18
+
+### Added
+- Inventory-backed routing now returns `authProfileOverride` when the winning same-provider account declares an `authProfile`
+- Routing logs now include the selected account id and auth profile when ZeroAPI makes an account-aware decision
+- Decision tests cover the new account-level selection output
+
+### Changed
+- OpenClaw now receives a preferred auth profile together with `providerOverride` and `modelOverride`, so same-provider multi-account routing can steer actual account choice instead of only provider-level scoring
+
 ## [3.3.0] — 2026-04-18
 
 ### Added
@@ -10,9 +20,6 @@
 ### Changed
 - Routing eligibility and subscription pressure can now come from `subscription_inventory` when it exists for a provider, while `subscription_profile` remains supported as the legacy/global-agent policy layer
 - Config validation now rejects array-shaped `subscription_profile` and `subscription_inventory` payloads instead of silently accepting malformed structures
-
-### Notes
-- ZeroAPI still selects `providerOverride` and `modelOverride` only. OpenClaw remains responsible for the actual auth profile rotation inside a provider via `auth.order`, cooldowns, and session pinning.
 
 ## [3.2.4] — 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.4.1] - 2026-04-18
+
+### Fixed
+- Same-provider multi-account routing now still returns `authProfileOverride` when the winning account keeps the same provider/model pair, so OpenClaw can move onto the right auth profile instead of treating it as a no-op
+- Added decision coverage for same-model auth-profile reroutes and the no-auth-profile fallback stay path
+
 ## [3.4.0] — 2026-04-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.4.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.4.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.4.0)
+[![Version](https://img.shields.io/badge/version-3.4.1-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.4.1)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.4.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.3.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.3.0)
+[![Version](https://img.shields.io/badge/version-3.4.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.4.0)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 
@@ -120,7 +120,7 @@ It lets ZeroAPI model that provider as an account pool instead of a single tier:
 }
 ```
 
-Current limitation: ZeroAPI still returns only `providerOverride` and `modelOverride`. OpenClaw remains responsible for real auth profile rotation inside that provider via `auth.order`, cooldowns, and session pinning. For best results, keep your OpenClaw `auth.order` aligned with the priorities in `subscription_inventory`.
+When the winning inventory account has an `authProfile`, ZeroAPI now returns `authProfileOverride` alongside `providerOverride` and `modelOverride`. OpenClaw still owns cooldown handling, failover, and session stickiness after that profile preference is applied.
 
 Before turning routing loose on real traffic, inspect a sample decision:
 
@@ -261,7 +261,7 @@ Yes. Use `/model` in OpenClaw or add a `#model:` directive at the top of your me
 Yes. ZeroAPI keeps a legacy global `subscription_profile` plus agent-level partial overrides. That lets one agent inherit the global provider set while another disables or narrows a provider without redefining the full profile.
 
 **Can ZeroAPI pick between multiple accounts for the same provider?**
-Partially. ZeroAPI can now score the provider as a pool with `subscription_inventory`, but the real per-turn account selection still belongs to OpenClaw runtime. OpenClaw rotates auth profiles with `auth.order`, cooldowns, and session stickiness. For best results, keep the account priorities in both places aligned.
+Yes. If `subscription_inventory` picks a specific account and that account defines `authProfile`, ZeroAPI returns it as `authProfileOverride`. OpenClaw then treats it as the preferred profile for the run, while still handling cooldowns, failover, and session stickiness.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.4.0
+version: 3.4.1
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when user mentions model routing, multi-model setup, "which model should I use",

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.3.0
+version: 3.4.0
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when user mentions model routing, multi-model setup, "which model should I use",
@@ -12,7 +12,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription.
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw","claude"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.2 — Plugin-Based Model Routing
+# ZeroAPI v3.4 — Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 

--- a/plugin/__tests__/decision.test.ts
+++ b/plugin/__tests__/decision.test.ts
@@ -145,14 +145,35 @@ describe("resolveRoutingDecision", () => {
     expect(result.selectedModel).toBe("zai/glm-5");
   });
 
-  it("stays on current model when the selected candidate already matches runtime state", () => {
+  it("reissues the current model when the winning account needs an auth profile override", () => {
     const result = resolveRoutingDecision(config, {
       prompt: "coordinate a workflow across 3 services",
       currentModel: "zai/glm-5",
     });
+    expect(result.action).toBe("route");
+    expect(result.selectedModel).toBe("zai/glm-5");
+    expect(result.providerOverride).toBe("zai");
+    expect(result.modelOverride).toBe("glm-5");
+    expect(result.authProfileOverride).toBe("zai:work");
+    expect(result.selectedAccountId).toBe("zai-max-work");
+    expect(result.finalDecision?.category).toBe("orchestration");
+  });
+
+  it("still stays on the current model when no auth profile override is needed", () => {
+    const result = resolveRoutingDecision(
+      {
+        ...config,
+        subscription_inventory: undefined,
+      },
+      {
+        prompt: "coordinate a workflow across 3 services",
+        currentModel: "zai/glm-5",
+      },
+    );
     expect(result.action).toBe("stay");
     expect(result.reason).toContain("no_switch_needed");
-    expect(result.finalDecision?.category).toBe("orchestration");
+    expect(result.authProfileOverride).toBeNull();
+    expect(result.selectedAccountId).toBeNull();
   });
 
   it("returns a clear stay reason when no eligible candidate remains", () => {

--- a/plugin/__tests__/decision.test.ts
+++ b/plugin/__tests__/decision.test.ts
@@ -63,6 +63,24 @@ const config: ZeroAPIConfig = {
       },
     },
   },
+  subscription_inventory: {
+    version: "1.0.0",
+    accounts: {
+      "zai-max-work": {
+        provider: "zai",
+        tierId: "max",
+        authProfile: "zai:work",
+        usagePriority: 3,
+        intendedUse: ["orchestration", "fast", "default"],
+      },
+      "openai-plus-personal": {
+        provider: "openai-codex",
+        tierId: "plus",
+        authProfile: "openai:personal",
+        usagePriority: 1,
+      },
+    },
+  },
 };
 
 describe("resolveRoutingDecision", () => {
@@ -96,6 +114,8 @@ describe("resolveRoutingDecision", () => {
     expect(result.selectedModel).toBe("zai/glm-5");
     expect(result.providerOverride).toBe("zai");
     expect(result.modelOverride).toBe("glm-5");
+    expect(result.authProfileOverride).toBe("zai:work");
+    expect(result.selectedAccountId).toBe("zai-max-work");
     expect(result.weightedCandidates).toEqual(["zai/glm-5", "openai-codex/gpt-5.4"]);
     expect(result.tokenEstimate).toBeGreaterThan(0);
   });
@@ -136,11 +156,17 @@ describe("resolveRoutingDecision", () => {
   });
 
   it("returns a clear stay reason when no eligible candidate remains", () => {
-    const result = resolveRoutingDecision(config, {
-      prompt: "quickly format this payload",
-      agentId: "constrained",
-      currentModel: config.default_model,
-    });
+    const result = resolveRoutingDecision(
+      {
+        ...config,
+        subscription_inventory: undefined,
+      },
+      {
+        prompt: "quickly format this payload",
+        agentId: "constrained",
+        currentModel: config.default_model,
+      },
+    );
     expect(result.action).toBe("stay");
     expect(result.reason).toContain("no_eligible_candidate");
     expect(result.capableModels).toHaveLength(0);

--- a/plugin/__tests__/inventory.test.ts
+++ b/plugin/__tests__/inventory.test.ts
@@ -94,4 +94,29 @@ describe("subscription inventory", () => {
     expect(resolved?.routingWeight).toBe(4);
     expect(resolved?.preferredAuthProfile).toBeNull();
   });
+
+  it("ignores non-string authProfile values in inventory accounts", () => {
+    const inventory = {
+      version: "1.0.0",
+      accounts: {
+        "openai-work-max": {
+          provider: "openai-codex",
+          tierId: "pro",
+          authProfile: 123,
+          usagePriority: 2,
+        },
+      },
+    } as unknown as SubscriptionInventory;
+
+    const resolved = resolveProviderCapacity({
+      profile,
+      inventory,
+      agentId: undefined,
+      providerId: "openai-codex",
+      category: "code",
+    });
+
+    expect(resolved?.source).toBe("inventory");
+    expect(resolved?.preferredAuthProfile).toBeNull();
+  });
 });

--- a/plugin/__tests__/inventory.test.ts
+++ b/plugin/__tests__/inventory.test.ts
@@ -43,6 +43,8 @@ describe("subscription inventory", () => {
     expect(resolved?.enabled).toBe(true);
     expect(resolved?.accountCount).toBe(2);
     expect(resolved?.matchedAccountIds).toContain("openai-work-max");
+    expect(resolved?.preferredAccountId).toBe("openai-work-max");
+    expect(resolved?.preferredAuthProfile).toBe("openai:work");
     expect(resolved?.routingWeight ?? 0).toBeGreaterThan(3);
   });
 
@@ -90,5 +92,6 @@ describe("subscription inventory", () => {
     expect(resolved?.source).toBe("profile");
     expect(resolved?.enabled).toBe(true);
     expect(resolved?.routingWeight).toBe(4);
+    expect(resolved?.preferredAuthProfile).toBeNull();
   });
 });

--- a/plugin/__tests__/logger.test.ts
+++ b/plugin/__tests__/logger.test.ts
@@ -46,7 +46,9 @@ describe("logger", () => {
 
     logRouting("agent-1", {
       action: "route",
+      authProfileOverride: "openai:work",
       currentModel: "zai/glm-5.1",
+      selectedAccountId: "openai-work-pro",
       weightedCandidates: ["openai-codex/gpt-5.4", "zai/glm-5.1"],
       finalDecision: {
         category: "code",
@@ -81,6 +83,8 @@ describe("logger", () => {
     expect(lines[0]).toContain("current=zai/glm-5.1");
     expect(lines[0]).toContain("model=openai-codex/gpt-5.4");
     expect(lines[0]).toContain("candidates=openai-codex/gpt-5.4,zai/glm-5.1");
+    expect(lines[0]).toContain("authProfile=openai:work");
+    expect(lines[0]).toContain("account=openai-work-pro");
     expect(lines[1]).toContain("agent=agent-2");
     expect(lines[1]).toContain("action=stay");
     expect(lines[1]).toContain("category=research");

--- a/plugin/decision.ts
+++ b/plugin/decision.ts
@@ -279,7 +279,20 @@ export function resolveRoutingDecision(
       )
     : null;
 
-  if (!selectedModel) {
+  const preferredCurrentModel =
+    selectedModel === null && weightedCandidates[0] === currentModel ? weightedCandidates[0] : null;
+  const targetModel = selectedModel ?? preferredCurrentModel;
+  const resolvedCapacity = targetModel
+    ? resolveProviderCapacity({
+        profile: config.subscription_profile,
+        inventory: config.subscription_inventory,
+        agentId,
+        providerId: splitModelKey(targetModel).provider,
+        category: rawDecision.category,
+      })
+    : null;
+
+  if (!targetModel) {
     const finalDecision = {
       ...rawDecision,
       model: null,
@@ -307,17 +320,42 @@ export function resolveRoutingDecision(
     };
   }
 
-  const { provider, model } = splitModelKey(selectedModel);
-  const resolvedCapacity = resolveProviderCapacity({
-    profile: config.subscription_profile,
-    inventory: config.subscription_inventory,
-    agentId,
-    providerId: provider,
-    category: rawDecision.category,
-  });
+  if (
+    selectedModel === null &&
+    currentModel === preferredCurrentModel &&
+    !resolvedCapacity?.preferredAuthProfile
+  ) {
+    const finalDecision = {
+      ...rawDecision,
+      model: null,
+      provider: null,
+      reason: `${rawDecision.reason}:no_switch_needed`,
+    };
+    return {
+      action: "stay",
+      reason: finalDecision.reason,
+      agentId,
+      trigger: options.trigger,
+      currentModel,
+      workspaceHints,
+      tokenEstimate,
+      likelyVision,
+      capableModels: Object.keys(capable),
+      weightedCandidates,
+      rawDecision,
+      finalDecision,
+      selectedModel: null,
+      providerOverride: null,
+      modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
+    };
+  }
+
+  const { provider, model } = splitModelKey(targetModel);
   const finalDecision = {
     ...rawDecision,
-    model: selectedModel,
+    model: targetModel,
     provider,
   };
 
@@ -334,7 +372,7 @@ export function resolveRoutingDecision(
     weightedCandidates,
     rawDecision,
     finalDecision,
-    selectedModel,
+    selectedModel: targetModel,
     providerOverride: provider,
     modelOverride: model,
     authProfileOverride: resolvedCapacity?.preferredAuthProfile ?? null,

--- a/plugin/decision.ts
+++ b/plugin/decision.ts
@@ -1,6 +1,6 @@
 import { classifyTask } from "./classifier.js";
 import { filterCapableModels, estimateTokens } from "./filter.js";
-import { isModelAllowedBySubscriptions } from "./inventory.js";
+import { isModelAllowedBySubscriptions, resolveProviderCapacity } from "./inventory.js";
 import { getSubscriptionWeightedCandidates } from "./router.js";
 import { selectModel } from "./selector.js";
 import type { RoutingDecision, TaskCategory, ZeroAPIConfig } from "./types.js";
@@ -44,6 +44,8 @@ export type RoutingResolution = {
   selectedModel: string | null;
   providerOverride: string | null;
   modelOverride: string | null;
+  authProfileOverride: string | null;
+  selectedAccountId: string | null;
 };
 
 function escapeRegex(value: string): string {
@@ -96,6 +98,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -116,6 +120,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -136,6 +142,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -170,6 +178,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -191,6 +201,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -247,6 +259,8 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
@@ -288,10 +302,19 @@ export function resolveRoutingDecision(
       selectedModel: null,
       providerOverride: null,
       modelOverride: null,
+      authProfileOverride: null,
+      selectedAccountId: null,
     };
   }
 
   const { provider, model } = splitModelKey(selectedModel);
+  const resolvedCapacity = resolveProviderCapacity({
+    profile: config.subscription_profile,
+    inventory: config.subscription_inventory,
+    agentId,
+    providerId: provider,
+    category: rawDecision.category,
+  });
   const finalDecision = {
     ...rawDecision,
     model: selectedModel,
@@ -314,5 +337,7 @@ export function resolveRoutingDecision(
     selectedModel,
     providerOverride: provider,
     modelOverride: model,
+    authProfileOverride: resolvedCapacity?.preferredAuthProfile ?? null,
+    selectedAccountId: resolvedCapacity?.preferredAccountId ?? null,
   };
 }

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { initLogger, logRouting, logRoutingEvent } from "./logger.js";
 
-const PLUGIN_VERSION = "3.3.0";
+const PLUGIN_VERSION = "3.4.0";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {
@@ -99,6 +99,9 @@ export default definePluginEntry({
         return {
           providerOverride: resolution.providerOverride!,
           modelOverride: resolution.modelOverride!,
+          ...(resolution.authProfileOverride
+            ? { authProfileOverride: resolution.authProfileOverride }
+            : {}),
         };
       }
     });

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { initLogger, logRouting, logRoutingEvent } from "./logger.js";
 
-const PLUGIN_VERSION = "3.4.0";
+const PLUGIN_VERSION = "3.4.1";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/inventory.ts
+++ b/plugin/inventory.ts
@@ -33,6 +33,12 @@ function getUsagePriorityFactor(priority: number | undefined): number {
   return 0.8 + (0.2 * clamp(priority ?? 1, 0, 3));
 }
 
+function normalizeAuthProfile(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized || null;
+}
+
 function resolveInventoryAccounts(params: {
   inventory: SubscriptionInventory | undefined;
   providerId: string;
@@ -57,7 +63,7 @@ function resolveInventoryAccounts(params: {
       weight:
         getAccountBaseWeight(providerId, account.tierId) *
         getUsagePriorityFactor(account.usagePriority),
-      authProfile: account.authProfile?.trim() || null,
+      authProfile: normalizeAuthProfile(account.authProfile),
       intendedUse: account.intendedUse ?? [],
     }));
 

--- a/plugin/inventory.ts
+++ b/plugin/inventory.ts
@@ -9,6 +9,8 @@ export type ResolvedProviderCapacity = {
   source: "inventory" | "profile";
   accountCount: number;
   matchedAccountIds: string[];
+  preferredAccountId: string | null;
+  preferredAuthProfile: string | null;
 };
 
 function clamp(value: number, min: number, max: number): number {
@@ -39,8 +41,8 @@ function resolveInventoryAccounts(params: {
   const { inventory, providerId, category } = params;
   if (!inventory) {
     return {
-      allAccounts: [] as Array<{ accountId: string; weight: number }>,
-      scoringAccounts: [] as Array<{ accountId: string; weight: number }>,
+      allAccounts: [] as Array<{ accountId: string; weight: number; authProfile: string | null }>,
+      scoringAccounts: [] as Array<{ accountId: string; weight: number; authProfile: string | null }>,
     };
   }
 
@@ -55,20 +57,29 @@ function resolveInventoryAccounts(params: {
       weight:
         getAccountBaseWeight(providerId, account.tierId) *
         getUsagePriorityFactor(account.usagePriority),
+      authProfile: account.authProfile?.trim() || null,
       intendedUse: account.intendedUse ?? [],
     }));
 
   if (enabledAccounts.length === 0) {
     return {
-      allAccounts: [] as Array<{ accountId: string; weight: number }>,
-      scoringAccounts: [] as Array<{ accountId: string; weight: number }>,
+      allAccounts: [] as Array<{ accountId: string; weight: number; authProfile: string | null }>,
+      scoringAccounts: [] as Array<{ accountId: string; weight: number; authProfile: string | null }>,
     };
   }
 
   if (!category) {
     return {
-      allAccounts: enabledAccounts.map(({ accountId, weight }) => ({ accountId, weight })),
-      scoringAccounts: enabledAccounts.map(({ accountId, weight }) => ({ accountId, weight })),
+      allAccounts: enabledAccounts.map(({ accountId, weight, authProfile }) => ({
+        accountId,
+        weight,
+        authProfile,
+      })),
+      scoringAccounts: enabledAccounts.map(({ accountId, weight, authProfile }) => ({
+        accountId,
+        weight,
+        authProfile,
+      })),
     };
   }
 
@@ -78,9 +89,38 @@ function resolveInventoryAccounts(params: {
   const scoringAccounts = matchedCategory.length > 0 ? matchedCategory : enabledAccounts;
 
   return {
-    allAccounts: enabledAccounts.map(({ accountId, weight }) => ({ accountId, weight })),
-    scoringAccounts: scoringAccounts.map(({ accountId, weight }) => ({ accountId, weight })),
+    allAccounts: enabledAccounts.map(({ accountId, weight, authProfile }) => ({
+      accountId,
+      weight,
+      authProfile,
+    })),
+    scoringAccounts: scoringAccounts.map(({ accountId, weight, authProfile }) => ({
+      accountId,
+      weight,
+      authProfile,
+    })),
   };
+}
+
+function pickPreferredInventoryAccount(
+  accounts: Array<{ accountId: string; weight: number; authProfile: string | null }>,
+): { accountId: string; authProfile: string | null } | null {
+  if (accounts.length === 0) return null;
+
+  const ranked = [...accounts].sort((a, b) => {
+    if (b.weight !== a.weight) {
+      return b.weight - a.weight;
+    }
+    return a.accountId.localeCompare(b.accountId);
+  });
+
+  const preferred = ranked[0];
+  return preferred
+    ? {
+        accountId: preferred.accountId,
+        authProfile: preferred.authProfile,
+      }
+    : null;
 }
 
 export function resolveProviderCapacity(params: {
@@ -106,11 +146,14 @@ export function resolveProviderCapacity(params: {
         source: "inventory",
         accountCount: 0,
         matchedAccountIds: [],
+        preferredAccountId: null,
+        preferredAuthProfile: null,
       };
     }
 
     const strongestAccount = Math.max(...accounts.scoringAccounts.map((account) => account.weight));
     const redundancyBonus = Math.min(1, 0.25 * Math.max(0, accounts.scoringAccounts.length - 1));
+    const preferredAccount = pickPreferredInventoryAccount(accounts.scoringAccounts);
 
     return {
       providerId,
@@ -119,6 +162,8 @@ export function resolveProviderCapacity(params: {
       source: "inventory",
       accountCount: accounts.allAccounts.length,
       matchedAccountIds: accounts.scoringAccounts.map((account) => account.accountId),
+      preferredAccountId: preferredAccount?.accountId ?? null,
+      preferredAuthProfile: preferredAccount?.authProfile ?? null,
     };
   }
 
@@ -132,6 +177,8 @@ export function resolveProviderCapacity(params: {
     source: "profile",
     accountCount: legacy.enabled ? 1 : 0,
     matchedAccountIds: [],
+    preferredAccountId: null,
+    preferredAuthProfile: null,
   };
 }
 

--- a/plugin/logger.ts
+++ b/plugin/logger.ts
@@ -7,6 +7,8 @@ let logPath: string | null = null;
 type LogEntry = {
   action?: string;
   agentId?: string;
+  authProfile?: string | null;
+  accountId?: string | null;
   category: string;
   currentModel?: string | null;
   model?: string | null;
@@ -29,9 +31,11 @@ export function logRouting(
   agentId: string | undefined,
   routing: {
     action: "skip" | "stay" | "route";
+    authProfileOverride?: string | null;
     currentModel: string | null;
     weightedCandidates: string[];
     finalDecision: RoutingDecision | null;
+    selectedAccountId?: string | null;
   },
 ): void {
   if (!routing.finalDecision) return;
@@ -39,6 +43,8 @@ export function logRouting(
   logRoutingEvent({
     action: routing.action,
     agentId,
+    authProfile: routing.authProfileOverride ?? null,
+    accountId: routing.selectedAccountId ?? null,
     category: routing.finalDecision.category,
     currentModel: routing.currentModel,
     model: routing.finalDecision.model ?? "default",
@@ -65,6 +71,12 @@ export function logRoutingEvent(entry: LogEntry): void {
 
   if (entry.candidates?.length) {
     parts.push(`candidates=${entry.candidates.join(",")}`);
+  }
+  if (entry.authProfile) {
+    parts.push(`authProfile=${entry.authProfile}`);
+  }
+  if (entry.accountId) {
+    parts.push(`account=${entry.accountId}`);
   }
 
   const line = `${parts.join(" ")}\n`;

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Benchmark-driven model routing across subscription providers",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Benchmark-driven model routing across subscription providers",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-router",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "description": "ZeroAPI — benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-router",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "private": true,
   "description": "ZeroAPI — benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -311,7 +311,7 @@ This file is not the runtime source of truth for OpenClaw itself. Think of it as
 | `benchmarks_date` | Date of the embedded benchmarks.json used to generate this config |
 | `subscription_catalog_version` | Public tier catalog version used when the config was generated |
 | `subscription_profile.global` | Enabled providers and selected subscription tiers. Missing or empty values can filter out all routing candidates. |
-| `subscription_inventory.accounts` | Preferred same-provider multi-account pool. Each account can declare `provider`, `tierId`, `authProfile`, `usagePriority`, and `intendedUse`. |
+| `subscription_inventory.accounts` | Preferred same-provider multi-account pool. Each account can declare `provider`, `tierId`, `authProfile`, `usagePriority`, and `intendedUse`. Winning accounts pass `authProfile` through as OpenClaw `authProfileOverride`. |
 | `default_model` | ZeroAPI's preferred default policy target. If `openclaw.json` differs, OpenClaw runtime default still wins unless a per-turn override is returned. |
 | `external_model_policy` | How ZeroAPI behaves when the active current model is outside its own `models` pool. `stay` keeps that foreign or external model. `allow` lets ZeroAPI re-enter and route back into its subscription pool. |
 | `models.<id>.context_window` | Maximum tokens the model can accept |

--- a/references/subscription-catalog.md
+++ b/references/subscription-catalog.md
@@ -113,7 +113,7 @@ Each account can carry:
 
 - `provider`
 - `tierId`
-- `authProfile` (metadata only for now)
+- `authProfile` (preferred OpenClaw auth profile id when that account wins)
 - `usagePriority`
 - `intendedUse`
 


### PR DESCRIPTION
## Summary
- add inventory-backed `authProfileOverride` output so ZeroAPI can tell OpenClaw which auth profile should run the selected account
- preserve that override even when the winning account keeps the same provider/model pair as the current runtime
- extend docs, changelog, and decision/logger tests for same-provider multi-account routing

## Why
Users can have multiple subscriptions under the same provider with different limits. Routing only by provider/model is not enough in that setup, because the right choice is often a different account behind the same runtime model.

This change restores the intended invariant: ZeroAPI should be able to steer account choice, not only provider choice, while still leaving cooldowns, failover, and session stickiness to OpenClaw.

Non-goals:
- this does not change unrelated API-key providers outside the ZeroAPI pool
- this does not replace OpenClaw's own auth rotation or cooldown logic

## Tests
- `cd plugin && npm test`

## Real-world validation
- deployed on my VPS against a live OpenClaw gateway
- validated same-provider multi-account routing flow with the downstream OpenClaw hook support patch

## Nearby path check
The risky adjacent path here is the existing `stay:no_switch_needed` branch. This PR keeps that stay behavior when no auth profile override is needed, and adds a decision test for that path.
