### PR TITLE
chore(tooling): add root npm scripts

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/show-your-config.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-your-config.yml
@@ -23,4 +23,4 @@ body:
     id: eval-output
     attributes:
       label: Eval output
-      description: Paste your `npx tsx scripts/eval.ts` output if you have routing data
+      description: Paste your `npm run eval` output if you have routing data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,5 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node-version }}
-      - run: cd plugin && npm install
-      - run: cd plugin && npm test
-      - run: node --test scripts/__tests__/*.test.mjs
+      - run: npm install
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -94,14 +94,14 @@ Recommended path:
 2. Open any OpenClaw chat channel
 3. Run /zeroapi (or /skill zeroapi if the channel exposes only generic skill commands)
 4. Answer the short setup questions
-5. Verify with bash scripts-zeroapi-doctor.sh or npx tsx scripts/simulate.ts --prompt "refactor this auth module"
-6. Preview cron model alignment with npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw
+5. Verify with bash scripts-zeroapi-doctor.sh or npm run simulate -- --prompt "refactor this auth module"
+6. Preview cron model alignment with npm run cron:audit -- --openclaw-dir ~/.openclaw
 ```
 
 Preferred host install:
 
 ```bash
-node scripts/managed_install.mjs --openclaw-dir ~/.openclaw
+npm run managed:install -- --openclaw-dir ~/.openclaw
 ```
 
 Managed install does four things in one pass:
@@ -115,12 +115,13 @@ Managed install does four things in one pass:
 If the host does not support `systemctl --user`, managed install still works, but the timer is skipped and the same updater can be run manually:
 
 ```bash
-node ~/.openclaw/zeroapi-managed/repo/scripts/managed_update.mjs --openclaw-dir ~/.openclaw
+cd ~/.openclaw/zeroapi-managed/repo
+npm run managed:update -- --openclaw-dir ~/.openclaw
 ```
 
 The `/zeroapi` skill is the primary public onboarding surface. It should feel natural inside chat channels: short questions, compact choices, and a final confirmation before writing `~/.openclaw/zeroapi-config.json`.
 
-`scripts/first_run.ts` is the **terminal-only fallback** for repo-local setups, operators who prefer shell access, or cases where the plugin/skill is not yet reachable from a chat surface. It asks which providers and tiers you want, optionally captures same-provider multi-account inventories, reuses current provider/modifier choices as defaults on reruns, writes `~/.openclaw/zeroapi-config.json`, and can hand off to managed install from the checked-out repo.
+`scripts/first_run.ts` is the **terminal-only fallback** for repo-local setups, operators who prefer shell access, or cases where the plugin/skill is not yet reachable from a chat surface. Run it with `npm run first-run`. It asks which providers and tiers you want, optionally captures same-provider multi-account inventories, reuses current provider/modifier choices as defaults on reruns, writes `~/.openclaw/zeroapi-config.json`, and can hand off to managed install from the checked-out repo.
 
 For managed install/update behavior, rollback rules, and timer semantics, see [`references/managed-install.md`](references/managed-install.md).
 
@@ -179,7 +180,7 @@ All three keep the same safety, capability, and subscription gates from balanced
 To see how modifiers differ on a real prompt set before enabling one globally:
 
 ```bash
-npx tsx scripts/compare_modifiers.ts --prompts-file prompts.txt
+npm run compare:modifiers -- --prompts-file prompts.txt
 ```
 
 ## Same-Provider Multi-Account
@@ -227,7 +228,7 @@ Important: the compatibility fallback only updates sessions that already exist i
 Before turning routing loose on real traffic, inspect a sample decision:
 
 ```bash
-npx tsx scripts/simulate.ts --prompt "coordinate a workflow across 3 services"
+npm run simulate -- --prompt "coordinate a workflow across 3 services"
 ```
 
 The simulator shows category, risk, current model, candidate pool, and the final route/stay/skip reason. It is the fastest way to see whether a config behaves the way the user expects.
@@ -240,7 +241,7 @@ Most routing plugins are set-and-forget. ZeroAPI is set-and-improve.
 Every routing decision is logged to `~/.openclaw/logs/zeroapi-routing.log`. The built-in eval script analyzes this data and tells you what to tune:
 
 ```bash
-npx tsx scripts/eval.ts --last 500
+npm run eval -- --last 500
 ```
 
 The report shows category distribution, risk override rate, provider diversity, keyword hit rates, and concrete tuning suggestions. All routing constants - keywords, risk levels, vision detection, TTFT thresholds, fallback ordering, and external-model handling - live in `zeroapi-config.json` and can be changed without touching code.
@@ -252,7 +253,7 @@ One important knob is `external_model_policy`:
 For one-off sanity checks before changing production traffic, use the simulator instead of waiting for live logs:
 
 ```bash
-npx tsx scripts/simulate.ts --prompt "quickly format this JSON payload"
+npm run simulate -- --prompt "quickly format this JSON payload"
 ```
 
 **The loop:** run eval, change one constant, restart gateway, wait for traffic, re-run eval. Keep what improves routing, revert what doesn't.
@@ -269,6 +270,7 @@ ZeroAPI/
 │       ├── secret-scan.yml
 │       └── test.yml
 ├── SKILL.md                              # Setup wizard — scans OpenClaw, configures routing
+├── package.json                          # Root scripts for tests and repo-local tools
 ├── benchmarks.json                       # 162 benchmark reference models, plus policy-family tags
 ├── policy-families.json                  # 11 practical policy-family members across 5 providers
 ├── scripts-zeroapi-doctor.sh             # Runtime/policy self-check helper
@@ -371,7 +373,7 @@ Claude subscriptions no longer cover third-party tools like OpenClaw as of April
 Google declared CLI OAuth usage with third-party tools a ToS violation as of March 25, 2026. Accounts using Gemini CLI OAuth through OpenClaw risk suspension. API key access (AI Studio/Vertex) is separate billing, not subscription-covered.
 
 **How accurate is routing?**
-Keyword/category routing is intentionally conservative. Some messages are routed, others stay on the current runtime default/current model. Inspect `~/.openclaw/logs/zeroapi-routing.log` for raw decisions or run `npx tsx scripts/eval.ts` for a tuning report, and treat routing as a policy hint layer rather than a guarantee that every message will switch models.
+Keyword/category routing is intentionally conservative. Some messages are routed, others stay on the current runtime default/current model. Inspect `~/.openclaw/logs/zeroapi-routing.log` for raw decisions or run `npm run eval` for a tuning report, and treat routing as a policy hint layer rather than a guarantee that every message will switch models.
 
 **Does it add latency?**
 Very little in normal operation. Classification is local (keyword/regex + config lookups) and does not call an external LLM, but actual end-to-end behavior still depends on OpenClaw runtime state and the selected provider.

--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ ZeroAPI is a **gateway plugin**. That means setup has two layers:
 Recommended path:
 
 ```
-1. Run managed install once on the OpenClaw host
-2. Open any OpenClaw chat channel
-3. Run /zeroapi (or /skill zeroapi if the channel exposes only generic skill commands)
-4. Answer the short setup questions
-5. Verify with bash scripts-zeroapi-doctor.sh or npm run simulate -- --prompt "refactor this auth module"
-6. Preview cron model alignment with npm run cron:audit -- --openclaw-dir ~/.openclaw
+1. Clone the repo and run npm install once
+2. Run managed install once on the OpenClaw host
+3. Open any OpenClaw chat channel
+4. Run /zeroapi (or /skill zeroapi if the channel exposes only generic skill commands)
+5. Answer the short setup questions
+6. Verify with bash scripts-zeroapi-doctor.sh or npm run simulate -- --prompt "refactor this auth module"
+7. Preview cron model alignment with npm run cron:audit -- --openclaw-dir ~/.openclaw
 ```
 
 Preferred host install:

--- a/SKILL.md
+++ b/SKILL.md
@@ -260,7 +260,7 @@ Required config shape:
 
 Agent model safety rule: if an OpenClaw agent already has its own model assignment, preserve that assignment. Put that agent in `workspace_hints` as `null` unless the user explicitly wants ZeroAPI to route it. If the user does want routing for that agent, use a category list such as `["code", "research"]`; this is an explicit opt-in.
 
-Cron model safety rule: runtime ZeroAPI hooks never route `trigger: "cron"` turns. Cron model selection is an offline config alignment step. Use `npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw` to preview which `agentTurn` jobs should get a `payload.model` and `payload.fallbacks` patch. Apply changes only after the user approves, preferably via OpenClaw's native `cron.update` tool so the gateway owns persistence. Do not patch `systemEvent` jobs; OpenClaw strips model fields there by design.
+Cron model safety rule: runtime ZeroAPI hooks never route `trigger: "cron"` turns. Cron model selection is an offline config alignment step. Use `npm run cron:audit -- --openclaw-dir ~/.openclaw` to preview which `agentTurn` jobs should get a `payload.model` and `payload.fallbacks` patch. Apply changes only after the user approves, preferably via OpenClaw's native `cron.update` tool so the gateway owns persistence. Do not patch `systemEvent` jobs; OpenClaw strips model fields there by design.
 
 `routing_modifier` is also optional. Leave it unset for plain balanced mode unless the user explicitly wants one of the shipped overlays.
 
@@ -385,14 +385,14 @@ ZeroAPI logs every routing decision to `~/.openclaw/logs/zeroapi-routing.log`. U
 Run:
 
 ```bash
-npx tsx scripts/eval.ts
+npm run eval
 ```
 
 Optional filters:
 
 ```bash
-npx tsx scripts/eval.ts --since 2026-04-01
-npx tsx scripts/eval.ts --last 500
+npm run eval -- --since 2026-04-01
+npm run eval -- --last 500
 ```
 
 ### Tunable constants
@@ -409,7 +409,7 @@ npx tsx scripts/eval.ts --last 500
 
 ### Tune loop
 
-1. Run eval: `npx tsx scripts/eval.ts`
+1. Run eval: `npm run eval`
 2. Edit one constant in `~/.openclaw/zeroapi-config.json`
 3. Restart the gateway so the plugin reloads the config
 4. Re-run eval on fresh traffic

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "zeroapi",
+  "version": "3.6.0",
+  "private": true,
+  "description": "Benchmark-driven model routing for OpenClaw",
+  "type": "module",
+  "workspaces": [
+    "plugin"
+  ],
+  "scripts": {
+    "test": "npm run test:plugin && npm run test:scripts",
+    "test:plugin": "npm --workspace zeroapi-router test",
+    "test:scripts": "node --test scripts/__tests__/*.test.mjs",
+    "simulate": "tsx scripts/simulate.ts",
+    "eval": "tsx scripts/eval.ts",
+    "compare:modifiers": "tsx scripts/compare_modifiers.ts",
+    "cron:audit": "tsx scripts/cron_audit.ts",
+    "first-run": "tsx scripts/first_run.ts",
+    "doctor": "bash scripts-zeroapi-doctor.sh",
+    "managed:install": "node scripts/managed_install.mjs",
+    "managed:update": "node scripts/managed_update.mjs",
+    "benchmarks:refresh": "python3 scripts/refresh_benchmarks.py"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.5"
+  }
+}

--- a/references/channel-onboarding.md
+++ b/references/channel-onboarding.md
@@ -24,7 +24,7 @@ Entry points:
 
 - `/zeroapi` when the channel exposes direct skill commands
 - `/skill zeroapi` when the channel exposes only the generic skill runner
-- `npx tsx scripts/first_run.ts` only as a terminal fallback
+- `npm run first-run` only as a terminal fallback
 
 ## Operator vs user responsibilities
 

--- a/references/cron-config.md
+++ b/references/cron-config.md
@@ -7,13 +7,13 @@ ZeroAPI does not route cron-triggered turns at runtime. OpenClaw resolves cron m
 Use the preview command before changing anything:
 
 ```bash
-npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw
+npm run cron:audit -- --openclaw-dir ~/.openclaw
 ```
 
 Machine-readable output:
 
 ```bash
-npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw --json
+npm run cron:audit -- --openclaw-dir ~/.openclaw --json
 ```
 
 The audit is read-only. It returns recommended `cron.update` payload patches, but it does not write `jobs.json` and does not restart the gateway. In chat-native onboarding, show the preview first and apply only user-approved changes via OpenClaw's `cron.update` tool.

--- a/references/routing-modifiers-spec.md
+++ b/references/routing-modifiers-spec.md
@@ -214,7 +214,7 @@ The goal is not "modifier changes many decisions." The goal is "modifier changes
 Practical helper:
 
 ```bash
-npx tsx scripts/compare_modifiers.ts --prompts-file prompts.txt
+npm run compare:modifiers -- --prompts-file prompts.txt
 ```
 
 That compares `balanced` against all shipped modifiers on the same prompt set and highlights only the changed decisions.

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -173,7 +173,7 @@ Log format:
 **Preview recommended cron patches**:
 
 ```bash
-npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw
+npm run cron:audit -- --openclaw-dir ~/.openclaw
 ```
 
 Only `payload.kind="agentTurn"` jobs can get `payload.model` and `payload.fallbacks`. `systemEvent` jobs inherit the main session path and should not be model-patched.

--- a/scripts/compare_modifiers.ts
+++ b/scripts/compare_modifiers.ts
@@ -81,8 +81,8 @@ function parseArgs(argv: string[]): CliOptions {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  npx tsx scripts/compare_modifiers.ts --prompts-file prompts.txt
-  echo "refactor auth module" | npx tsx scripts/compare_modifiers.ts
+  npm run compare:modifiers -- --prompts-file prompts.txt
+  echo "refactor auth module" | npm run compare:modifiers
 
 Options:
   --prompt <text>         Add a single prompt (repeatable)

--- a/scripts/cron_audit.ts
+++ b/scripts/cron_audit.ts
@@ -50,8 +50,8 @@ function parseArgs(argv: string[]): CliOptions {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  npx tsx scripts/cron_audit.ts --openclaw-dir ~/.openclaw
-  npx tsx scripts/cron_audit.ts --jobs ~/.openclaw/cron/jobs.json --json
+  npm run cron:audit -- --openclaw-dir ~/.openclaw
+  npm run cron:audit -- --jobs ~/.openclaw/cron/jobs.json --json
 
 Options:
   --openclaw-dir <path>  OpenClaw config directory. Default: ~/.openclaw

--- a/scripts/eval.ts
+++ b/scripts/eval.ts
@@ -10,9 +10,9 @@
  *   - keyword hit distribution
  *
  * Usage:
- *   npx tsx scripts/eval.ts                   # all entries
- *   npx tsx scripts/eval.ts --since 2026-04-01 # filter by date
- *   npx tsx scripts/eval.ts --last 100         # last N entries
+ *   npm run eval                              # all entries
+ *   npm run eval -- --since 2026-04-01        # filter by date
+ *   npm run eval -- --last 100                # last N entries
  */
 
 import { readFileSync, existsSync } from "fs";

--- a/scripts/first_run.ts
+++ b/scripts/first_run.ts
@@ -45,8 +45,8 @@ function parseArgs(argv: string[]) {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  npx tsx scripts/first_run.ts
-  npx tsx scripts/first_run.ts --openclaw-dir ~/.openclaw
+  npm run first-run
+  npm run first-run -- --openclaw-dir ~/.openclaw
 
 This interactive wizard writes a starter zeroapi-config.json for the selected providers.
 `);
@@ -518,7 +518,7 @@ async function main() {
     console.log("1. Yukarıdaki auth komutlarıyla seçtiğin provider'ları bağla.");
     console.log("2. openclaw models status");
     console.log("3. bash scripts-zeroapi-doctor.sh");
-    console.log('4. npx tsx scripts/simulate.ts --prompt "refactor the auth module"');
+    console.log('4. npm run simulate -- --prompt "refactor the auth module"');
     console.log("5. Gerekirse modifier davranışını compare_modifiers ile kıyasla.");
   } finally {
     rl.close();

--- a/scripts/managed_install.mjs
+++ b/scripts/managed_install.mjs
@@ -43,9 +43,9 @@ function parseArgs(argv) {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  node scripts/managed_install.mjs
-  node scripts/managed_install.mjs --openclaw-dir ~/.openclaw
-  node scripts/managed_install.mjs --no-timer --no-restart
+  npm run managed:install
+  npm run managed:install -- --openclaw-dir ~/.openclaw
+  npm run managed:install -- --no-timer --no-restart
 `);
       process.exit(0);
     }

--- a/scripts/managed_update.mjs
+++ b/scripts/managed_update.mjs
@@ -30,8 +30,8 @@ function parseArgs(argv) {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  node scripts/managed_update.mjs
-  node scripts/managed_update.mjs --openclaw-dir ~/.openclaw
+  npm run managed:update
+  npm run managed:update -- --openclaw-dir ~/.openclaw
 `);
       process.exit(0);
     }

--- a/scripts/simulate.ts
+++ b/scripts/simulate.ts
@@ -62,8 +62,8 @@ function parseArgs(argv: string[]): CliOptions {
     }
     if (arg === "--help" || arg === "-h") {
       console.log(`Usage:
-  npx tsx scripts/simulate.ts --prompt "refactor auth module"
-  echo "refactor auth module" | npx tsx scripts/simulate.ts --agent codex
+  npm run simulate -- --prompt "refactor auth module"
+  echo "refactor auth module" | npm run simulate -- --agent codex
 
 Options:
   --prompt <text>         Prompt to classify and route


### PR DESCRIPTION
## Summary
- add a root package.json with npm scripts for tests and repo-local tools
- switch CI to the same root npm test command users run locally
- update docs and CLI help examples to use the root scripts

## Why
New users should not need to remember which commands run from the root and which commands run from plugin/. The repo now has one obvious command surface for install, simulation, eval, cron audit, and tests.

## Tests
- npm install
- npm test
- npm run cron:audit -- --help
- npm run simulate -- --help
- npm run compare:modifiers -- --help
- npm run first-run -- --help
- npm run managed:install -- --help
- npm run managed:update -- --help

## Real-world validation
- Verified the root commands locally from a clean branch.

## Non-goals
- Does not change routing behavior or OpenClaw runtime config.