### PR TITLE
feat(cron): explain audit confidence

### DIFF
--- a/plugin/__tests__/cron-audit.test.ts
+++ b/plugin/__tests__/cron-audit.test.ts
@@ -107,6 +107,8 @@ describe("auditCronJob", () => {
 
     expect(result.action).toBe("change");
     expect(result.category).toBe("code");
+    expect(result.confidence).toBe("high");
+    expect(result.matchedSignals).toContain("keyword:fix");
     expect(result.suggestedModel).toBe("openai-codex/gpt-5.4");
     expect(result.patch?.payload).toEqual({
       kind: "agentTurn",
@@ -145,8 +147,26 @@ describe("auditCronJob", () => {
     });
 
     expect(result.category).toBe("fast");
+    expect(result.confidence).toBe("medium");
+    expect(result.matchedSignals).toContain("cron_hint:health_check:watchdog");
     expect(result.reason).toBe("change:cron_hint:health_check");
     expect(result.suggestedModel).toBe("zai/glm-5.1");
+  });
+
+  it("marks unmatched cron prompts as low confidence", () => {
+    const result = auditCronJob(config, {
+      id: "ambiguous",
+      name: "Ambiguous recurring task",
+      enabled: true,
+      payload: {
+        kind: "agentTurn",
+        message: "handle the usual weekly thing",
+      },
+    });
+
+    expect(result.category).toBe("default");
+    expect(result.confidence).toBe("low");
+    expect(result.matchedSignals).toContain("no_match");
   });
 
   it("does not touch systemEvent cron jobs", () => {
@@ -197,6 +217,8 @@ describe("auditCronJob", () => {
 
     expect(result.action).toBe("review");
     expect(result.reason).toContain("review:high_risk");
+    expect(result.confidence).toBe("high");
+    expect(result.matchedSignals).toContain("high_risk_keyword:deploy");
     expect(result.patch).toBeNull();
   });
 });

--- a/plugin/cron-audit.ts
+++ b/plugin/cron-audit.ts
@@ -52,12 +52,15 @@ export type CronAuditJob = {
 };
 
 export type CronAuditAction = "skip" | "keep" | "change" | "review";
+export type CronAuditConfidence = "low" | "medium" | "high";
 
 export type CronAuditItem = {
   id: string;
   name: string;
   action: CronAuditAction;
   reason: string;
+  confidence: CronAuditConfidence;
+  matchedSignals: string[];
   agentId: string | null;
   sessionTarget: string | null;
   category: TaskCategory | null;
@@ -138,22 +141,89 @@ function likelyRequiresVision(config: ZeroAPIConfig, prompt: string): boolean {
   return keywords.some((keyword) => hasWholeKeyword(promptLower, keyword));
 }
 
-function applyCronCategoryHint(
-  prompt: string,
-  decision: ReturnType<typeof classifyTask>,
-): ReturnType<typeof classifyTask> {
-  if (decision.category !== "default" || decision.risk === "high") return decision;
-
+function findCronCategoryHint(prompt: string): { category: TaskCategory; reason: string; keyword: string } | null {
   const promptLower = prompt.toLowerCase();
-  const hint = CRON_CATEGORY_HINTS.find((entry) =>
-    entry.keywords.some((keyword) => hasCronKeyword(promptLower, keyword)),
+  for (const entry of CRON_CATEGORY_HINTS) {
+    const keyword = entry.keywords.find((candidate) => hasCronKeyword(promptLower, candidate));
+    if (keyword) {
+      return { category: entry.category, reason: entry.reason, keyword };
+    }
+  }
+  return null;
+}
+
+function extractMatchedSignals(reason: string): string[] {
+  const signals: string[] = [];
+  const keywordMatch = reason.match(/(?:^|:)keyword:([^:]+)/);
+  if (keywordMatch?.[1]) signals.push(`keyword:${keywordMatch[1]}`);
+  const workspaceMatch = reason.match(/(?:^|:)workspace_hint:([^:]+)/);
+  if (workspaceMatch?.[1]) signals.push(`workspace_hint:${workspaceMatch[1]}`);
+  const highRiskMatch = reason.match(/(?:^|:)high_risk_keyword:([^:]+)/);
+  if (highRiskMatch?.[1]) signals.push(`high_risk_keyword:${highRiskMatch[1]}`);
+  if (reason === "no_match") signals.push("no_match");
+  if (reason === "empty_prompt") signals.push("empty_prompt");
+  return signals;
+}
+
+function resolveConfidence(params: {
+  reason: string;
+  risk: RiskLevel;
+  matchedSignals: string[];
+}): CronAuditConfidence {
+  const { reason, risk, matchedSignals } = params;
+  if (risk === "high") return "high";
+  if (matchedSignals.some((signal) => signal.startsWith("keyword:"))) return "high";
+  if (matchedSignals.some((signal) => signal.startsWith("cron_hint:"))) return "medium";
+  if (matchedSignals.some((signal) => signal.startsWith("workspace_hint:"))) return "medium";
+  if (reason === "no_match" || reason === "empty_prompt") return "low";
+  return "medium";
+}
+
+function classifyCronPrompt(params: {
+  config: ZeroAPIConfig;
+  prompt: string;
+  workspaceHints?: TaskCategory[] | null;
+}): {
+  decision: ReturnType<typeof classifyTask>;
+  confidence: CronAuditConfidence;
+  matchedSignals: string[];
+} {
+  const { config, prompt, workspaceHints } = params;
+  const decision = classifyTask(
+    prompt,
+    config.keywords,
+    config.high_risk_keywords,
+    workspaceHints === null ? undefined : workspaceHints,
+    config.risk_levels,
   );
-  if (!hint) return decision;
+  const matchedSignals = extractMatchedSignals(decision.reason);
+
+  if (decision.category === "default" && decision.risk !== "high") {
+    const hint = findCronCategoryHint(prompt);
+    if (hint) {
+      const hintedDecision = {
+        ...decision,
+        category: hint.category,
+        reason: hint.reason,
+      };
+      const hintName = hint.reason.replace(/^cron_hint:/, "");
+      const hintedSignals = [`cron_hint:${hintName}:${hint.keyword}`];
+      return {
+        decision: hintedDecision,
+        confidence: resolveConfidence({
+          reason: hintedDecision.reason,
+          risk: hintedDecision.risk,
+          matchedSignals: hintedSignals,
+        }),
+        matchedSignals: hintedSignals,
+      };
+    }
+  }
 
   return {
-    ...decision,
-    category: hint.category,
-    reason: hint.reason,
+    decision,
+    confidence: resolveConfidence({ reason: decision.reason, risk: decision.risk, matchedSignals }),
+    matchedSignals,
   };
 }
 
@@ -218,6 +288,8 @@ export function auditCronJob(
     ...base,
     currentModel,
     currentFallbacks,
+    confidence: "high" as CronAuditConfidence,
+    matchedSignals: [],
     suggestedModel: null,
     suggestedFallbacks: [],
     weightedCandidates: [],
@@ -250,6 +322,8 @@ export function auditCronJob(
       ...common,
       action: "review",
       reason: "review:empty_prompt",
+      confidence: "low",
+      matchedSignals: ["empty_prompt"],
       category: null,
       risk: null,
     };
@@ -257,16 +331,12 @@ export function auditCronJob(
 
   const agentId = base.agentId ?? undefined;
   const workspaceHints = agentId ? config.workspace_hints[agentId] : undefined;
-  const decision = applyCronCategoryHint(
+  const classification = classifyCronPrompt({
+    config,
     prompt,
-    classifyTask(
-      prompt,
-      config.keywords,
-      config.high_risk_keywords,
-      workspaceHints === null ? undefined : workspaceHints,
-      config.risk_levels,
-    ),
-  );
+    workspaceHints,
+  });
+  const { decision, confidence, matchedSignals } = classification;
   const weightedCandidates = resolveWeightedCandidates({
     config,
     category: decision.category,
@@ -281,6 +351,8 @@ export function auditCronJob(
     ...common,
     category: decision.category,
     risk: decision.risk,
+    confidence,
+    matchedSignals,
     suggestedModel,
     suggestedFallbacks,
     weightedCandidates,

--- a/references/cron-config.md
+++ b/references/cron-config.md
@@ -28,6 +28,8 @@ The audit is read-only. It returns recommended `cron.update` payload patches, bu
 
 The audit uses cron-specific hints when the normal chat classifier has no strong keyword match. Examples: `health`, `watchdog`, `status`, `freshness`, and `reminder` map to `fast`; `sync`, `ci`, `build`, `test`, `repo`, and `github` map to `code`; `audit`, `digest`, `engage`, and `moderation` map to `research`.
 
+Each audit item includes `confidence` and `matchedSignals` so operators can see whether a recommendation came from a strong chat keyword, a cron-specific hint, a workspace hint, or a high-risk guardrail. Treat `low` confidence rows as manual review candidates even when the suggested model is technically eligible.
+
 **Conservative default:** first run is preview-only. User explicitly opts in per job. Re-run shows a diff and requires confirmation.
 
 ## Audit actions

--- a/scripts/cron_audit.ts
+++ b/scripts/cron_audit.ts
@@ -138,6 +138,7 @@ function renderText(report: CronAuditReport, jobsPath: string): string {
   for (const item of report.items) {
     lines.push(`- [${item.action}] ${item.name} (${item.id})`);
     lines.push(`  reason: ${item.reason}`);
+    lines.push(`  confidence: ${item.confidence} | signals: ${formatList(item.matchedSignals)}`);
     if (item.category) lines.push(`  category: ${item.category}, risk: ${item.risk ?? "unknown"}`);
     if (item.agentId) lines.push(`  agent: ${item.agentId}`);
     lines.push(`  current: ${item.currentModel ?? "inherits OpenClaw default"} | fallbacks: ${formatList(item.currentFallbacks)}`);


### PR DESCRIPTION
## Summary
- add `confidence` and `matchedSignals` to every cron audit item
- show confidence and signal details in the cron audit text output
- document how operators should treat low-confidence cron recommendations

## Why
Cron recommendations should be explainable before operators apply model changes. This makes it clear whether a suggestion came from a strong task keyword, a cron-specific hint, a workspace hint, or a high-risk guardrail.

## Tests
- npm test
- npm run cron:audit -- --help

## Real-world validation
- Verified CLI help locally and added tests for keyword, cron hint, unmatched, and high-risk signal output.

## Non-goals
- Does not apply cron changes automatically. This remains preview-only.