### PR TITLE
feat(cron): add guarded apply helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@
 ## [Unreleased]
 
 ### Changed
+- Added root npm scripts for repo-local tests, simulation, eval, cron audit/apply, first-run, doctor, and managed install/update flows.
 - Added a preview-only cron audit command that reads OpenClaw cron jobs, classifies `agentTurn` payloads, and recommends `payload.model` / `payload.fallbacks` patches without writing `jobs.json`.
+- Cron audit output now includes recommendation `confidence` and `matchedSignals`, making it clear whether a model suggestion came from a task keyword, cron hint, workspace hint, or high-risk guardrail.
+- Added a dry-run-first cron apply helper that writes a timestamped backup before applying approved `agentTurn` model/fallback patches and skips low-confidence changes by default.
 - Aligned public onboarding/auth guidance with current upstream OpenClaw provider flows: OpenAI uses `openclaw models auth login --provider openai-codex`, MiniMax uses `minimax-portal`, and Qwen routes through `qwen-portal/coder-model`.
 - Managed install/update now writes state before restarting the gateway and schedules the restart through user systemd when possible, so chat-driven installs do not leave partial plugin state if the gateway stops the running agent.
 - Managed install now uses a longer scheduled restart grace period and documents that chat-based installers should reply before running follow-up host checks.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Recommended path:
 5. Answer the short setup questions
 6. Verify with bash scripts-zeroapi-doctor.sh or npm run simulate -- --prompt "refactor this auth module"
 7. Preview cron model alignment with npm run cron:audit -- --openclaw-dir ~/.openclaw
+8. Apply approved cron changes with npm run cron:apply -- --openclaw-dir ~/.openclaw --yes
 ```
 
 Preferred host install:
@@ -278,6 +279,7 @@ ZeroAPI/
 ├── scripts/
 │   ├── first_run.ts                      # Interactive starter wizard for public repo onboarding
 │   ├── cron_audit.ts                     # Preview-only OpenClaw cron model/fallback audit
+│   ├── cron_apply.ts                     # Dry-run-first cron model/fallback apply helper
 │   ├── eval.ts                           # Routing log analyzer
 │   ├── compare_modifiers.ts              # Prompt-set delta checker for balanced vs modifiers
 │   ├── refresh_benchmarks.py             # Refreshes benchmarks.json from AA API v2

--- a/SKILL.md
+++ b/SKILL.md
@@ -260,7 +260,7 @@ Required config shape:
 
 Agent model safety rule: if an OpenClaw agent already has its own model assignment, preserve that assignment. Put that agent in `workspace_hints` as `null` unless the user explicitly wants ZeroAPI to route it. If the user does want routing for that agent, use a category list such as `["code", "research"]`; this is an explicit opt-in.
 
-Cron model safety rule: runtime ZeroAPI hooks never route `trigger: "cron"` turns. Cron model selection is an offline config alignment step. Use `npm run cron:audit -- --openclaw-dir ~/.openclaw` to preview which `agentTurn` jobs should get a `payload.model` and `payload.fallbacks` patch. Apply changes only after the user approves, preferably via OpenClaw's native `cron.update` tool so the gateway owns persistence. Do not patch `systemEvent` jobs; OpenClaw strips model fields there by design.
+Cron model safety rule: runtime ZeroAPI hooks never route `trigger: "cron"` turns. Cron model selection is an offline config alignment step. Use `npm run cron:audit -- --openclaw-dir ~/.openclaw` to preview which `agentTurn` jobs should get a `payload.model` and `payload.fallbacks` patch. Apply changes only after the user approves, preferably via OpenClaw's native `cron.update` tool so the gateway owns persistence. If shell access is the only available path, use `npm run cron:apply -- --openclaw-dir ~/.openclaw --yes`; it is dry-run by default, writes a backup before changes, and skips low-confidence changes unless explicitly allowed. Do not patch `systemEvent` jobs; OpenClaw strips model fields there by design.
 
 `routing_modifier` is also optional. Leave it unset for plain balanced mode unless the user explicitly wants one of the shipped overlays.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eval": "tsx scripts/eval.ts",
     "compare:modifiers": "tsx scripts/compare_modifiers.ts",
     "cron:audit": "tsx scripts/cron_audit.ts",
+    "cron:apply": "tsx scripts/cron_apply.ts",
     "first-run": "tsx scripts/first_run.ts",
     "doctor": "bash scripts-zeroapi-doctor.sh",
     "managed:install": "node scripts/managed_install.mjs",

--- a/plugin/__tests__/cron-apply.test.ts
+++ b/plugin/__tests__/cron-apply.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { applyCronAuditPatches } from "../cron-apply.js";
+import type { CronAuditJob, CronAuditReport } from "../cron-audit.js";
+
+const jobs: CronAuditJob[] = [
+  {
+    id: "safe-change",
+    name: "Safe change",
+    payload: {
+      kind: "agentTurn",
+      message: "fix tests",
+      model: "zai/glm-5.1",
+      fallbacks: ["zai/glm-5"],
+    },
+  },
+  {
+    id: "low-confidence",
+    name: "Low confidence",
+    payload: {
+      kind: "agentTurn",
+      message: "handle weekly thing",
+      model: "zai/glm-5.1",
+    },
+  },
+];
+
+const report: CronAuditReport = {
+  totalJobs: 2,
+  counts: { skip: 0, keep: 0, change: 2, review: 0 },
+  items: [
+    {
+      id: "safe-change",
+      name: "Safe change",
+      action: "change",
+      reason: "change:keyword:fix",
+      confidence: "high",
+      matchedSignals: ["keyword:fix"],
+      agentId: null,
+      sessionTarget: null,
+      category: "code",
+      risk: "medium",
+      currentModel: "zai/glm-5.1",
+      currentFallbacks: ["zai/glm-5"],
+      suggestedModel: "openai-codex/gpt-5.4",
+      suggestedFallbacks: ["zai/glm-5.1"],
+      weightedCandidates: ["openai-codex/gpt-5.4", "zai/glm-5.1"],
+      patch: {
+        payload: {
+          kind: "agentTurn",
+          model: "openai-codex/gpt-5.4",
+          fallbacks: ["zai/glm-5.1"],
+        },
+      },
+    },
+    {
+      id: "low-confidence",
+      name: "Low confidence",
+      action: "change",
+      reason: "change:no_match",
+      confidence: "low",
+      matchedSignals: ["no_match"],
+      agentId: null,
+      sessionTarget: null,
+      category: "default",
+      risk: "low",
+      currentModel: "zai/glm-5.1",
+      currentFallbacks: [],
+      suggestedModel: "openai-codex/gpt-5.4",
+      suggestedFallbacks: ["zai/glm-5.1"],
+      weightedCandidates: ["openai-codex/gpt-5.4", "zai/glm-5.1"],
+      patch: {
+        payload: {
+          kind: "agentTurn",
+          model: "openai-codex/gpt-5.4",
+          fallbacks: ["zai/glm-5.1"],
+        },
+      },
+    },
+  ],
+};
+
+describe("applyCronAuditPatches", () => {
+  it("applies high-confidence changes and skips low-confidence changes by default", () => {
+    const result = applyCronAuditPatches(jobs, report);
+
+    expect(result.applied.map((item) => item.id)).toEqual(["safe-change"]);
+    expect(result.skipped).toContainEqual(
+      expect.objectContaining({ id: "low-confidence", reason: "skip:low_confidence" }),
+    );
+    expect(result.jobs[0].payload).toMatchObject({
+      kind: "agentTurn",
+      model: "openai-codex/gpt-5.4",
+      fallbacks: ["zai/glm-5.1"],
+    });
+    expect(result.jobs[1].payload).toMatchObject({ model: "zai/glm-5.1" });
+  });
+
+  it("can apply low-confidence changes when explicitly allowed", () => {
+    const result = applyCronAuditPatches(jobs, report, { includeLowConfidence: true });
+
+    expect(result.applied.map((item) => item.id)).toEqual(["safe-change", "low-confidence"]);
+  });
+
+  it("can apply a selected job subset", () => {
+    const result = applyCronAuditPatches(jobs, report, { jobIds: ["low-confidence"], includeLowConfidence: true });
+
+    expect(result.applied.map((item) => item.id)).toEqual(["low-confidence"]);
+    expect(result.skipped).toContainEqual(expect.objectContaining({ id: "safe-change", reason: "skip:not_selected" }));
+  });
+});

--- a/plugin/cron-apply.ts
+++ b/plugin/cron-apply.ts
@@ -1,0 +1,91 @@
+import type { CronAuditJob, CronAuditReport } from "./cron-audit.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+export type CronApplyOptions = {
+  includeLowConfidence?: boolean;
+  jobIds?: string[];
+};
+
+export type CronApplyDecision = {
+  id: string;
+  name: string;
+  action: "apply" | "skip";
+  reason: string;
+  confidence: string;
+  model: string | null;
+  fallbacks: string[];
+};
+
+export type CronApplyResult = {
+  jobs: CronAuditJob[];
+  applied: CronApplyDecision[];
+  skipped: CronApplyDecision[];
+};
+
+function isRecord(value: unknown): value is UnknownRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeJobIds(jobIds: string[] | undefined): Set<string> | null {
+  if (!jobIds?.length) return null;
+  return new Set(jobIds.map((id) => id.trim()).filter(Boolean));
+}
+
+export function applyCronAuditPatches(
+  jobs: CronAuditJob[],
+  report: CronAuditReport,
+  options: CronApplyOptions = {},
+): CronApplyResult {
+  const allowedJobIds = normalizeJobIds(options.jobIds);
+  const applied: CronApplyDecision[] = [];
+  const skipped: CronApplyDecision[] = [];
+
+  const nextJobs = jobs.map((job, index) => {
+    const item = report.items[index];
+    if (!item) return job;
+
+    const decisionBase = {
+      id: item.id,
+      name: item.name,
+      confidence: item.confidence,
+      model: item.patch?.payload.model ?? null,
+      fallbacks: item.patch?.payload.fallbacks ?? [],
+    };
+
+    if (allowedJobIds && !allowedJobIds.has(item.id)) {
+      skipped.push({ ...decisionBase, action: "skip", reason: "skip:not_selected" });
+      return job;
+    }
+
+    if (item.action !== "change" || !item.patch) {
+      skipped.push({ ...decisionBase, action: "skip", reason: `skip:${item.action}` });
+      return job;
+    }
+
+    if (item.confidence === "low" && !options.includeLowConfidence) {
+      skipped.push({ ...decisionBase, action: "skip", reason: "skip:low_confidence" });
+      return job;
+    }
+
+    const payload = isRecord(job.payload) ? job.payload : {};
+    const nextPayload: UnknownRecord = {
+      ...payload,
+      kind: "agentTurn",
+      model: item.patch.payload.model,
+    };
+    if (item.patch.payload.fallbacks?.length) {
+      nextPayload.fallbacks = item.patch.payload.fallbacks;
+    } else {
+      delete nextPayload.fallbacks;
+    }
+
+    applied.push({ ...decisionBase, action: "apply", reason: item.reason });
+    return {
+      ...job,
+      payload: nextPayload,
+    };
+  });
+
+  return { jobs: nextJobs, applied, skipped };
+}

--- a/references/cron-config.md
+++ b/references/cron-config.md
@@ -18,6 +18,15 @@ npm run cron:audit -- --openclaw-dir ~/.openclaw --json
 
 The audit is read-only. It returns recommended `cron.update` payload patches, but it does not write `jobs.json` and does not restart the gateway. In chat-native onboarding, show the preview first and apply only user-approved changes via OpenClaw's `cron.update` tool.
 
+Shell fallback:
+
+```bash
+npm run cron:apply -- --openclaw-dir ~/.openclaw
+npm run cron:apply -- --openclaw-dir ~/.openclaw --yes
+```
+
+`cron:apply` is dry-run by default. With `--yes`, it writes a timestamped backup next to `jobs.json` before patching eligible `agentTurn` jobs. It skips low-confidence changes unless `--include-low-confidence` is passed, and `--job-id <id>` can scope the write to selected jobs.
+
 | Cron Task Type | Detection Signal | Model Criteria |
 |---------------|------------------|----------------|
 | Health check / status | Reads file, checks thresholds | Cheapest fast model, low TTFT |

--- a/references/troubleshooting.md
+++ b/references/troubleshooting.md
@@ -176,6 +176,12 @@ Log format:
 npm run cron:audit -- --openclaw-dir ~/.openclaw
 ```
 
+**Apply approved cron patches with backup**:
+
+```bash
+npm run cron:apply -- --openclaw-dir ~/.openclaw --yes
+```
+
 Only `payload.kind="agentTurn"` jobs can get `payload.model` and `payload.fallbacks`. `systemEvent` jobs inherit the main session path and should not be model-patched.
 
 ---

--- a/scripts/cron_apply.ts
+++ b/scripts/cron_apply.ts
@@ -1,0 +1,221 @@
+#!/usr/bin/env npx tsx
+
+import { copyFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { applyCronAuditPatches } from "../plugin/cron-apply.js";
+import { auditCronJobs, type CronAuditJob } from "../plugin/cron-audit.js";
+import { loadConfig } from "../plugin/config.js";
+
+type UnknownRecord = Record<string, unknown>;
+
+type CliOptions = {
+  openclawDir: string;
+  jobsPath?: string;
+  backupPath?: string;
+  yes: boolean;
+  json: boolean;
+  includeDisabled: boolean;
+  includeLowConfidence: boolean;
+  jobIds: string[];
+};
+
+function fail(message: string): never {
+  console.error(`ERROR: ${message}`);
+  process.exit(1);
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {
+    openclawDir: `${process.env.HOME ?? "/root"}/.openclaw`,
+    yes: false,
+    json: false,
+    includeDisabled: false,
+    includeLowConfidence: false,
+    jobIds: [],
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--openclaw-dir" && argv[i + 1]) {
+      options.openclawDir = argv[++i];
+      continue;
+    }
+    if (arg === "--jobs" && argv[i + 1]) {
+      options.jobsPath = argv[++i];
+      continue;
+    }
+    if (arg === "--backup" && argv[i + 1]) {
+      options.backupPath = argv[++i];
+      continue;
+    }
+    if (arg === "--job-id" && argv[i + 1]) {
+      options.jobIds.push(argv[++i]);
+      continue;
+    }
+    if (arg === "--yes") {
+      options.yes = true;
+      continue;
+    }
+    if (arg === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (arg === "--include-disabled") {
+      options.includeDisabled = true;
+      continue;
+    }
+    if (arg === "--include-low-confidence") {
+      options.includeLowConfidence = true;
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      console.log(`Usage:
+  npm run cron:apply -- --openclaw-dir ~/.openclaw
+  npm run cron:apply -- --openclaw-dir ~/.openclaw --yes
+  npm run cron:apply -- --jobs ~/.openclaw/cron/jobs.json --job-id ci-review --yes
+
+Options:
+  --openclaw-dir <path>       OpenClaw config directory. Default: ~/.openclaw
+  --jobs <path>               Explicit cron jobs.json path
+  --backup <path>             Explicit backup path for --yes writes
+  --job-id <id>               Apply only selected job id. Repeatable
+  --include-disabled          Include disabled jobs in audit recommendations
+  --include-low-confidence    Allow low-confidence audit changes to apply
+  --json                      Emit machine-readable JSON
+  --yes                       Write changes. Without this, dry-run only
+
+This command is dry-run by default. With --yes it writes a backup next to
+jobs.json before updating eligible agentTurn job payloads.
+`);
+      process.exit(0);
+    }
+    fail(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function expandHome(input: string): string {
+  if (input === "~") return process.env.HOME ?? input;
+  if (input.startsWith("~/")) return join(process.env.HOME ?? "~", input.slice(2));
+  return input;
+}
+
+function parseJsonFile(path: string): unknown {
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch (err) {
+    fail(`Could not parse JSON at ${path}: ${String(err)}`);
+  }
+}
+
+function resolveConfiguredCronStore(openclawDir: string): string | null {
+  const configPath = join(openclawDir, "openclaw.json");
+  if (!existsSync(configPath)) return null;
+  const parsed = parseJsonFile(configPath);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const cron = (parsed as { cron?: unknown }).cron;
+  if (!cron || typeof cron !== "object" || Array.isArray(cron)) return null;
+  const store = (cron as { store?: unknown }).store;
+  if (typeof store !== "string" || !store.trim()) return null;
+  const expanded = expandHome(store.trim());
+  return isAbsolute(expanded) ? expanded : resolve(dirname(configPath), expanded);
+}
+
+function resolveJobsPath(options: CliOptions): string {
+  if (options.jobsPath) {
+    const expanded = expandHome(options.jobsPath);
+    return isAbsolute(expanded) ? expanded : resolve(expanded);
+  }
+  return resolveConfiguredCronStore(options.openclawDir) ?? join(options.openclawDir, "cron", "jobs.json");
+}
+
+function loadCronStore(path: string): { store: UnknownRecord; jobs: CronAuditJob[] } {
+  if (!existsSync(path)) {
+    fail(`Cron jobs file not found: ${path}`);
+  }
+  const parsed = parseJsonFile(path);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    fail(`Cron store must be an object: ${path}`);
+  }
+  const jobs = (parsed as { jobs?: unknown }).jobs;
+  if (!Array.isArray(jobs)) {
+    fail(`Cron store has no jobs array: ${path}`);
+  }
+  return { store: parsed as UnknownRecord, jobs: jobs as CronAuditJob[] };
+}
+
+function timestamp(): string {
+  return new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+function defaultBackupPath(jobsPath: string): string {
+  return `${jobsPath}.zeroapi.${timestamp()}.bak`;
+}
+
+function renderText(params: {
+  jobsPath: string;
+  backupPath: string | null;
+  dryRun: boolean;
+  applied: ReturnType<typeof applyCronAuditPatches>["applied"];
+  skipped: ReturnType<typeof applyCronAuditPatches>["skipped"];
+}): string {
+  const lines = [
+    "# ZeroAPI Cron Apply",
+    "",
+    `Jobs file: ${params.jobsPath}`,
+    `Mode: ${params.dryRun ? "dry-run" : "write"}`,
+    `Backup: ${params.backupPath ?? "-"}`,
+    `Applied: ${params.applied.length}`,
+    `Skipped: ${params.skipped.length}`,
+    "",
+  ];
+
+  for (const item of params.applied) {
+    lines.push(`- [apply] ${item.name} (${item.id})`);
+    lines.push(`  model: ${item.model ?? "-"} | fallbacks: ${item.fallbacks.length ? item.fallbacks.join(", ") : "-"}`);
+    lines.push(`  confidence: ${item.confidence} | reason: ${item.reason}`);
+  }
+
+  for (const item of params.skipped.filter((entry) => entry.reason === "skip:low_confidence")) {
+    lines.push(`- [skip] ${item.name} (${item.id})`);
+    lines.push(`  reason: ${item.reason}. Re-run with --include-low-confidence to allow it.`);
+  }
+
+  return lines.join("\n");
+}
+
+const options = parseArgs(process.argv.slice(2));
+const openclawDir = resolve(expandHome(options.openclawDir));
+const config = loadConfig(openclawDir);
+if (!config) {
+  fail(`Could not load valid zeroapi-config.json from ${openclawDir}`);
+}
+
+const jobsPath = resolveJobsPath({ ...options, openclawDir });
+const { store, jobs } = loadCronStore(jobsPath);
+const report = auditCronJobs(config, jobs, { includeDisabled: options.includeDisabled });
+const result = applyCronAuditPatches(jobs, report, {
+  includeLowConfidence: options.includeLowConfidence,
+  jobIds: options.jobIds,
+});
+const backupPath = options.yes && result.applied.length > 0 ? resolve(expandHome(options.backupPath ?? defaultBackupPath(jobsPath))) : null;
+
+if (options.yes && result.applied.length > 0) {
+  copyFileSync(jobsPath, backupPath ?? defaultBackupPath(jobsPath));
+  writeFileSync(jobsPath, `${JSON.stringify({ ...store, jobs: result.jobs }, null, 2)}\n`, "utf-8");
+}
+
+const output = {
+  jobsPath,
+  backupPath,
+  dryRun: !options.yes,
+  applied: result.applied,
+  skipped: result.skipped,
+};
+
+if (options.json) {
+  console.log(JSON.stringify(output, null, 2));
+} else {
+  console.log(renderText(output));
+}


### PR DESCRIPTION
## Summary
- add a dry-run-first `cron:apply` CLI for approved cron model/fallback changes
- back cron apply with a pure helper and vitest coverage
- document backup, low-confidence skip, and selected job apply behavior

## Why
Cron audit gave useful recommendations but had no safe product-owned apply path. This adds a guarded shell fallback for operators while keeping chat-native onboarding preview-first.

## Tests
- npm test
- npm run cron:apply -- --help

## Real-world validation
- Verified the CLI help locally and covered high-confidence, low-confidence, and selected-job apply behavior in tests.

## Non-goals
- Does not route cron turns at runtime.
- Does not change OpenClaw systemEvent jobs.
- Does not bypass the user approval requirement.