### PR TITLE
test(onboarding): add fresh install transcript fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added a preview-only cron audit command that reads OpenClaw cron jobs, classifies `agentTurn` payloads, and recommends `payload.model` / `payload.fallbacks` patches without writing `jobs.json`.
 - Cron audit output now includes recommendation `confidence` and `matchedSignals`, making it clear whether a model suggestion came from a task keyword, cron hint, workspace hint, or high-risk guardrail.
 - Added a dry-run-first cron apply helper that writes a timestamped backup before applying approved `agentTurn` model/fallback patches and skips low-confidence changes by default.
+- Added a fresh-install golden transcript fixture that locks the channel-first repo explanation, install, provider, verify, and cron setup contract.
 - Aligned public onboarding/auth guidance with current upstream OpenClaw provider flows: OpenAI uses `openclaw models auth login --provider openai-codex`, MiniMax uses `minimax-portal`, and Qwen routes through `qwen-portal/coder-model`.
 - Managed install/update now writes state before restarting the gateway and schedules the restart through user systemd when possible, so chat-driven installs do not leave partial plugin state if the gateway stops the running agent.
 - Managed install now uses a longer scheduled restart grace period and documents that chat-based installers should reply before running follow-up host checks.

--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ ZeroAPI/
 │       └── session-auth.test.ts
 ├── examples/
 │   ├── README.md
+│   ├── fresh-install-transcript.json
 │   ├── openai-only.json
 │   ├── openai-glm.json
 │   ├── openai-glm-kimi.json

--- a/examples/fresh-install-transcript.json
+++ b/examples/fresh-install-transcript.json
@@ -1,0 +1,61 @@
+{
+  "schema": "zeroapi.fresh_install_transcript.v1",
+  "scenario": "fresh OpenClaw user asks about the ZeroAPI GitHub repo, then installs it from chat",
+  "steps": [
+    {
+      "id": "repo-explain",
+      "user": "https://github.com/dorukardahan/ZeroAPI bu repo ne iş yapıyor? bizim için faydalı olur mu?",
+      "assistant_must": [
+        "explain ZeroAPI neutrally before checking local state",
+        "describe gateway-level routing for active AI subscriptions",
+        "say it is useful for multi-provider or multi-account OpenClaw setups"
+      ],
+      "assistant_must_not": [
+        "claim the repo belongs to the user",
+        "claim ZeroAPI is already installed",
+        "inspect host config before the user asks to install or check"
+      ]
+    },
+    {
+      "id": "install-intent",
+      "user": "kuralım",
+      "assistant_must": [
+        "state that setup is channel-first but host install may need one operator command",
+        "ask for supported active subscriptions with compact numbered choices",
+        "avoid asking for secrets in chat"
+      ],
+      "supported_provider_choices": [
+        "OpenAI",
+        "Kimi",
+        "Z AI",
+        "MiniMax",
+        "Qwen Portal"
+      ]
+    },
+    {
+      "id": "subscription-tiers",
+      "user": "OpenAI Plus and Pro, Z AI Max",
+      "assistant_must": [
+        "detect same-provider OpenAI account pool",
+        "ask only for missing tier/account details",
+        "keep balanced routing as the default unless the user chooses a modifier"
+      ]
+    },
+    {
+      "id": "host-install",
+      "assistant_must": [
+        "tell the operator to run npm install once after clone",
+        "use npm run managed:install -- --openclaw-dir ~/.openclaw",
+        "queue or explain a delayed gateway restart after install"
+      ]
+    },
+    {
+      "id": "verify-and-cron",
+      "assistant_must": [
+        "verify with scripts-zeroapi-doctor.sh or npm run simulate",
+        "preview cron changes with npm run cron:audit",
+        "apply only approved cron changes with npm run cron:apply -- --yes"
+      ]
+    }
+  ]
+}

--- a/references/channel-onboarding.md
+++ b/references/channel-onboarding.md
@@ -58,6 +58,8 @@ The `/zeroapi` flow should behave like a compact chat wizard:
 - adapt the **first rerun question** to the detected drift kind instead of restarting from a generic provider survey
 - when the user is only asking "what is this repo?", answer that neutrally before inspecting or mentioning the current host install
 
+The fresh-install golden path is tracked in [`../examples/fresh-install-transcript.json`](../examples/fresh-install-transcript.json) and covered by the script tests. Update that fixture whenever the first-run chat contract changes.
+
 Good style:
 
 ```text

--- a/scripts/__tests__/fresh-install-transcript.test.mjs
+++ b/scripts/__tests__/fresh-install-transcript.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const transcript = JSON.parse(readFileSync(new URL("../../examples/fresh-install-transcript.json", import.meta.url)));
+const steps = new Map(transcript.steps.map((step) => [step.id, step]));
+
+test("fresh install transcript has the expected scenario steps", () => {
+  assert.equal(transcript.schema, "zeroapi.fresh_install_transcript.v1");
+  assert.deepEqual(
+    transcript.steps.map((step) => step.id),
+    ["repo-explain", "install-intent", "subscription-tiers", "host-install", "verify-and-cron"],
+  );
+});
+
+test("fresh repo explanation forbids ownership and stale install assumptions", () => {
+  const step = steps.get("repo-explain");
+  assert.ok(step.assistant_must.some((line) => line.includes("explain ZeroAPI neutrally")));
+  assert.ok(step.assistant_must_not.some((line) => line.includes("claim the repo belongs to the user")));
+  assert.ok(step.assistant_must_not.some((line) => line.includes("already installed")));
+  assert.ok(step.assistant_must_not.some((line) => line.includes("inspect host config")));
+});
+
+test("fresh install flow covers provider choices without chat secrets", () => {
+  const step = steps.get("install-intent");
+  assert.deepEqual(step.supported_provider_choices, ["OpenAI", "Kimi", "Z AI", "MiniMax", "Qwen Portal"]);
+  assert.ok(step.assistant_must.some((line) => line.includes("avoid asking for secrets")));
+});
+
+test("host and cron steps use guarded npm commands", () => {
+  const hostInstall = steps.get("host-install").assistant_must.join("\n");
+  const verifyAndCron = steps.get("verify-and-cron").assistant_must.join("\n");
+  assert.match(hostInstall, /npm install/);
+  assert.match(hostInstall, /npm run managed:install -- --openclaw-dir ~\/\.openclaw/);
+  assert.match(verifyAndCron, /npm run cron:audit/);
+  assert.match(verifyAndCron, /npm run cron:apply -- --yes/);
+});


### PR DESCRIPTION
## Summary
- add a golden transcript fixture for the fresh channel-first install path
- test the repo explanation, install intent, provider choices, host install, verify, and cron steps
- link the fixture from the channel onboarding reference and README tree

## Why
Fresh users should not get stale memory claims like "this is your repo" or "already installed" when they only paste the GitHub URL. This fixture turns that product contract into a testable artifact.

## Tests
- npm test

## Real-world validation
- The fixture encodes the exact failure mode observed in live Slack testing and protects the corrected first-run behavior.

## Non-goals
- Does not change runtime routing behavior.
- Does not install anything automatically.