### PR TITLE
docs: clarify static quota assumptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Cron audit output now includes recommendation `confidence` and `matchedSignals`, making it clear whether a model suggestion came from a task keyword, cron hint, workspace hint, or high-risk guardrail.
 - Added a dry-run-first cron apply helper that writes a timestamped backup before applying approved `agentTurn` model/fallback patches and skips low-confidence changes by default.
 - Added a fresh-install golden transcript fixture that locks the channel-first repo explanation, install, provider, verify, and cron setup contract.
+- Clarified that subscription/account headroom is static configured policy input, not live provider quota or private usage telemetry.
 - Aligned public onboarding/auth guidance with current upstream OpenClaw provider flows: OpenAI uses `openclaw models auth login --provider openai-codex`, MiniMax uses `minimax-portal`, and Qwen routes through `qwen-portal/coder-model`.
 - Managed install/update now writes state before restarting the gateway and schedules the restart through user systemd when possible, so chat-driven installs do not leave partial plugin state if the gateway stops the running agent.
 - Managed install now uses a longer scheduled restart grace period and documents that chat-based installers should reply before running follow-up host checks.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For the written product contract behind the current router, see [`references/rou
 **What makes it different:**
 - **Balanced by default** — optimizes for sustainable quality, not blind benchmark chasing
 - **Benchmark-aware** — routes by real benchmark scores (Artificial Analysis), not vibes
-- **Subscription-aware** — respects your provider tiers and biases toward high-headroom plans
+- **Subscription-aware** — uses your declared provider tiers, account priorities, and intended-use hints without reading private live quota data
 - **Data-driven tuning** — built-in eval script analyzes routing logs and suggests config improvements
 - **Zero runtime cost** — keyword classification under 1ms, no LLM call, no external API
 - **Cross-provider fallback** — every category has fallbacks spanning multiple providers
@@ -45,11 +45,13 @@ The plugin fires before eligible messages via OpenClaw's `before_model_resolve` 
 
 1. **Capability filter** — eliminate models that cannot fit the task (context window, vision, auth, rate limit)
 2. **Subscription filter** — eliminate models not allowed by the user's legacy profile or preferred account inventory
-3. **Benchmark frontier** — keep only candidates that stay close enough to the category leader for their subscription/headroom profile
-4. **Subscription pressure ordering** — inside that frontier, prefer providers whose tier and provider bias make them more appropriate for routine use
+3. **Benchmark frontier** — keep only candidates that stay close enough to the category leader for their declared subscription profile
+4. **Subscription pressure ordering** — inside that frontier, prefer providers whose configured tier and account hints make them more appropriate for routine use
 5. **Benchmark fallback order** — outside the frontier, fall back in benchmark strength order
 
-The default policy mode is `balanced`. That means ZeroAPI will not blindly force the raw benchmark winner on every turn. It only lets subscription headroom reorder candidates when they stay close enough to the category leader. This is the intended default for users who have uneven subscription limits across providers.
+The default policy mode is `balanced`. That means ZeroAPI will not blindly force the raw benchmark winner on every turn. It only lets declared subscription/account capacity reorder candidates when they stay close enough to the category leader. This is the intended default for users who have uneven subscription limits across providers.
+
+Important: ZeroAPI does **not** read provider dashboards, live remaining quota, billing counters, or private usage telemetry. In v1, "headroom" means a static policy signal derived from configured tier, `usagePriority`, `intendedUse`, and account count.
 
 When the hook returns an override, the model is switched for that turn only. The session, conversation history, and workspace files remain intact. OpenClaw runtime state is still the authority.
 
@@ -135,7 +137,7 @@ As of the new subscription-aware foundation, the config can include:
 - a persistent global subscription profile
 - a preferred `subscription_inventory` for same-provider multi-account setups
 - agent-level partial overrides for provider availability
-- benchmark-frontier routing that can bias toward high-headroom providers like GLM Max without letting weak candidates jump the queue
+- benchmark-frontier routing that can bias toward higher-capacity configured providers like GLM Max without letting weak candidates jump the queue
 
 The user declares what subscriptions they have. ZeroAPI decides the route.
 
@@ -149,7 +151,7 @@ If OpenClaw gains a newly usable **supported provider** or a new same-provider *
 
 In plain terms:
 - keep the benchmark leader when the quality gap is meaningful
-- let stronger subscription headroom win when benchmark quality stays near the leader
+- let stronger declared subscription/account capacity win when benchmark quality stays near the leader
 - do not let weak candidates jump the queue just because the subscription is larger
 
 Task-aware modifiers can now sit on top of this baseline without replacing it. The default shipping contract is still one clear default: sustainable quality optimization.

--- a/references/account-pool-spec.md
+++ b/references/account-pool-spec.md
@@ -14,10 +14,12 @@ That matters when a user has cases like:
 - one account meant for coding and another meant for routine traffic
 - multiple same-provider accounts where quota resilience matters
 
+ZeroAPI does not inspect live provider quota, remaining messages, or billing counters. In this spec, "headroom" means static configured capacity from tier weights, `usagePriority`, `intendedUse`, and bounded redundancy.
+
 ## Goals
 
 - keep same-provider account choice deterministic
-- let higher subscription headroom matter without making the pool opaque
+- let higher declared subscription/account capacity matter without making the pool opaque
 - make `usagePriority` and `intendedUse` meaningful but bounded
 - leave a clean future slot for depletion or usage-pressure signals
 

--- a/references/product-roadmap.md
+++ b/references/product-roadmap.md
@@ -22,12 +22,13 @@ These decisions are already locked unless there is a deliberate product change:
 - ZeroAPI is a subscription-focused routing layer, not a generic API-key router
 - Public benchmark data ships as a committed snapshot, not by exposing the Artificial Analysis API key
 - Same-provider multi-account routing is modeled via `subscription_inventory`
+- Subscription/account headroom is static policy input today, not live quota telemetry
 - OpenClaw runtime state remains the authority; ZeroAPI suggests routing and account preference
 
 ## Product principles
 
 1. Benchmark quality still leads.
-2. Subscription headroom may reorder only benchmark-near candidates.
+2. Declared subscription/account capacity may reorder only benchmark-near candidates.
 3. Manual user choices win over automatic routing.
 4. Public repo behavior must stay generic and operator-safe.
 5. Every routing rule that matters should be explainable in one short sentence.

--- a/references/routing-modifiers-spec.md
+++ b/references/routing-modifiers-spec.md
@@ -121,7 +121,7 @@ Use when the operator wants stronger protection for code quality and does not wa
 Intent:
 
 - preserve stronger coding leaders when the benchmark gap is real
-- still allow high-headroom subscriptions to win near-ties
+- still allow higher-capacity configured subscriptions to win near-ties
 
 Current shipped behavior:
 
@@ -133,7 +133,7 @@ Current shipped behavior:
 What it should feel like:
 
 - GPT-class coding leaders stay in front more often when they are clearly better
-- GLM/Kimi/Qwen still win routine coding turns when they are close enough and the user has stronger headroom there
+- GLM/Kimi/Qwen still win routine coding turns when they are close enough and the user has stronger declared capacity there
 
 ### 2. `research-aware`
 
@@ -153,7 +153,7 @@ Current shipped behavior:
 
 What it should feel like:
 
-- top reasoning models are harder to displace just because another provider has more quota
+- top reasoning models are harder to displace just because another provider has stronger configured capacity
 - subscription pressure still matters when research candidates are genuinely close
 
 ### 3. `speed-aware`

--- a/references/routing-policy-spec.md
+++ b/references/routing-policy-spec.md
@@ -7,7 +7,8 @@ This document describes what ZeroAPI means by balanced routing today. It is a pr
 ## Goals
 
 - preserve benchmark leadership when the quality gap is meaningful
-- allow subscription headroom to reorder only benchmark-near candidates
+- allow declared subscription/account capacity to reorder only benchmark-near candidates
+- define "headroom" as static configured tier/account capacity, not live remaining quota
 - keep manual user/runtime choices above automatic routing
 - make same-provider multi-account routing deterministic enough to explain
 
@@ -112,7 +113,7 @@ Note: benchmark values above 1 are normalized to percentages divided by 100 befo
 
 ## Benchmark frontier
 
-Balanced does not directly sort all candidates by subscription headroom. It first asks whether a candidate is close enough to the strongest benchmark score.
+Balanced does not directly sort all candidates by subscription/account capacity. It first asks whether a candidate is close enough to the strongest benchmark score.
 
 For each candidate:
 
@@ -150,7 +151,7 @@ Candidates outside the frontier are sorted by:
 This is the core balanced rule:
 
 - benchmark quality defines who is even allowed to compete for first place
-- subscription headroom only reorders that benchmark-near set
+- declared subscription/account capacity only reorders that benchmark-near set
 
 ## Route vs stay behavior
 

--- a/references/subscription-catalog.md
+++ b/references/subscription-catalog.md
@@ -2,6 +2,8 @@
 
 This document defines the provider and subscription catalog used by ZeroAPI for subscription-aware routing.
 
+ZeroAPI does not read live provider quota or private usage telemetry. Catalog weights are static policy hints based on public/provider-declared tiers and account-quota shape.
+
 ## Goals
 
 - Let users select from known subscription tiers instead of free-form text
@@ -153,8 +155,8 @@ It should only shape selection among benchmark-near candidates.
 Practical intent:
 
 - OpenAI may remain benchmark leader for many categories
-- GLM Max may still deserve stronger routine preference if the user has much more headroom there
-- Lower-headroom subscriptions should not dominate every task just because they benchmark slightly higher
+- GLM Max may still deserve stronger routine preference if the user configured much more capacity there
+- Lower-capacity configured subscriptions should not dominate every task just because they benchmark slightly higher
 
 That is why catalog entries can carry a provider-level routing bias, while tiers carry a tier-level routing weight.
 The router uses two layers:
@@ -165,7 +167,7 @@ The router uses two layers:
    - only candidates inside that drop window can compete for first place
 
 2. Subscription pressure ordering:
-   - inside the frontier, higher headroom providers sort earlier
+   - inside the frontier, higher configured-capacity providers sort earlier
    - outside the frontier, candidates stay in benchmark order
 
 The effective pressure signal is:
@@ -175,7 +177,7 @@ The effective pressure signal is:
 - tier routing weight
 - provider benchmark bias
 
-This stays heuristic in v1. Real usage telemetry comes later, but the frontier rule keeps the heuristic from overwhelming benchmark quality.
+This stays heuristic in v1. Real usage telemetry comes later, but the frontier rule keeps static tier/account hints from overwhelming benchmark quality.
 
 ## Files to Add in v1
 


### PR DESCRIPTION
## Summary
- clarify that ZeroAPI does not read live provider quota, billing counters, or private usage telemetry
- define headroom as static configured tier/account capacity
- align README, policy specs, account-pool docs, catalog docs, roadmap, and changelog wording

## Why
Subscription-aware routing should not imply live quota telemetry. These docs make the current v1 behavior explicit and preserve the future extension point for real usage-pressure signals.

## Tests
- npm test
- grep for misleading quota/headroom wording

## Real-world validation
- Verified docs now distinguish static policy input from real remaining quota.

## Non-goals
- Does not implement provider quota telemetry.
- Does not change routing behavior.