### PR TITLE
chore(release): prepare 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-04-22
+
 ### Changed
 - Added root npm scripts for repo-local tests, simulation, eval, cron audit/apply, first-run, doctor, and managed install/update flows.
 - Added a preview-only cron audit command that reads OpenClaw cron jobs, classifies `agentTurn` payloads, and recommends `payload.model` / `payload.fallbacks` patches without writing `jobs.json`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.4.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.6.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.6.0)
+[![Version](https://img.shields.io/badge/version-3.7.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.7.0)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.6.0
+version: 3.7.0
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when user mentions model routing, multi-model setup, "which model should I use",
@@ -12,7 +12,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Sa
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw","claude"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.6.0 - Plugin-Based Model Routing
+# ZeroAPI v3.7.0 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -228,7 +228,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.0.0",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -8,7 +8,7 @@ import { syncSessionAuthProfileOverride } from "./session-auth.js";
 import { startSubscriptionAdvisoryMonitor } from "./subscription-advisory.js";
 import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 
-const PLUGIN_VERSION = "3.6.0";
+const PLUGIN_VERSION = "3.7.0";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Balanced benchmark-aware model routing across subscription providers",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-router",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": true,
   "description": "ZeroAPI — balanced benchmark-aware routing for OpenClaw",
   "type": "module",

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -245,7 +245,7 @@ This file is not the runtime source of truth for OpenClaw itself. Think of it as
 
 ```json
 {
-  "version": "3.6.0",
+  "version": "3.7.0",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<YYYY-MM-DD>",
   "subscription_catalog_version": "1.0.0",


### PR DESCRIPTION
## Summary
- bump ZeroAPI package, plugin manifest, runtime constant, examples, docs, and badge to 3.7.0
- move Unreleased changes into a 2026-04-22 3.7.0 changelog section

## Why
The product work from the stabilization pass should ship as a named feature release instead of staying as an ambiguous Unreleased block.

## Tests
- npm test
- grep for stale 3.6.0 references outside changelog history/test fixtures

## Real-world validation
- Verified public-facing version references now point to v3.7.0.

## Non-goals
- Does not create the GitHub release tag until after this PR is reviewed and merged.