### PR TITLE
fix: align ZeroAPI with OpenClaw 2026.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+- Aligned Kimi starter configs and examples with OpenClaw v2026.4.20's `moonshot/kimi-k2.6` default, while using the committed K2.5 benchmark row as an explicit temporary proxy until the benchmark refresh includes native K2.6 data.
+- Documented OpenClaw's new cron `jobs-state.json` split so ZeroAPI cron helpers keep patching job definitions only and never touch runtime state.
+- Corrected same-provider account steering docs: OpenClaw v2026.4.20 still does not merge `authProfileOverride` from `before_model_resolve`, so ZeroAPI's session-store compatibility path remains required.
+
 ## [3.7.0] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If an OpenClaw agent is already running a non-default model and that agent has n
 | Provider | OpenClaw ID | Subscription | Monthly | Annual (eff/mo) | Models |
 |----------|------------|--------------|---------|-----------------|--------|
 | OpenAI | `openai-codex` | ChatGPT Plus / Pro | $20-$200 | $17-$167 | GPT-5.4, GPT-5.3 Codex, GPT-5.4 mini |
-| Kimi | `moonshot` (`kimi`, `kimi-coding` aliases) | Moderato-Vivace | $19-$199 | $15-$159 | Kimi K2.5, K2 Thinking |
+| Kimi | `moonshot` (`kimi`, `kimi-coding` legacy aliases) | Moderato-Vivace | $19-$199 | $15-$159 | Kimi K2.6, K2.5, K2 Thinking |
 | Z AI (GLM) | `zai` | Lite-Max | $10-$80 | $7-$56 | GLM-5.1, GLM-5, GLM-5-Turbo, GLM-4.7-Flash |
 | MiniMax | `minimax-portal` (`minimax` alias) | Starter-Max | $10-$50 | $8-$42 | MiniMax-M2.7 |
 | Qwen Portal | `qwen-portal` (`qwen`, `qwen-dashscope` aliases) | Free OAuth | $0 | $0 | coder-model |
@@ -225,7 +225,7 @@ Current scoring contract in plain terms:
 
 For the exact rules and formulas, see [`references/account-pool-spec.md`](references/account-pool-spec.md).
 
-When the winning inventory account has an `authProfile`, ZeroAPI returns `authProfileOverride` alongside `providerOverride` and `modelOverride`. On newer OpenClaw builds that hook field is consumed directly. On older builds, ZeroAPI now also performs a best-effort session-store sync so the active session can still prefer the right auth profile without waiting for upstream hook support. OpenClaw still owns cooldown handling, failover, and session stickiness after that profile preference is applied.
+When the winning inventory account has an `authProfile`, ZeroAPI returns `authProfileOverride` alongside `providerOverride` and `modelOverride` for forward compatibility, and also performs a best-effort session-store sync so the active session can prefer the right auth profile. OpenClaw v2026.4.20 still does not merge `authProfileOverride` from `before_model_resolve`, so the session-store path remains the runtime path for same-provider account steering. OpenClaw still owns cooldown handling, failover, and session stickiness after that profile preference is applied.
 
 Important: the compatibility fallback only updates sessions that already exist in OpenClaw's session store and it never overwrites a user-pinned auth profile. If the session store is unavailable, `subscription_inventory` still improves provider weighting and the final same-provider account choice falls back to OpenClaw `auth.order`.
 
@@ -391,7 +391,7 @@ Yes. Use `/model` in OpenClaw or add a `#model:` directive at the top of your me
 Yes. ZeroAPI keeps a legacy global `subscription_profile` plus agent-level partial overrides. That lets one agent inherit the global provider set while another disables or narrows a provider without redefining the full profile.
 
 **Can ZeroAPI pick between multiple accounts for the same provider?**
-Yes. If `subscription_inventory` picks a specific account and that account defines `authProfile`, ZeroAPI returns it as `authProfileOverride`. Newer OpenClaw builds consume that hook field directly. Older builds use ZeroAPI's best-effort session-store fallback when the session already exists, and otherwise keep relying on `auth.order` inside that provider.
+Yes. If `subscription_inventory` picks a specific account and that account defines `authProfile`, ZeroAPI keeps that preferred account in sync through OpenClaw session state. OpenClaw v2026.4.20 still only consumes `providerOverride` and `modelOverride` from `before_model_resolve`, so the session-store compatibility path remains required for same-provider account steering. If a session does not exist yet, OpenClaw still falls back to its native `auth.order` inside that provider.
 
 ## License
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -8,7 +8,7 @@ description: >
   Do NOT use for single-model conversations or general chat.
 homepage: https://github.com/dorukardahan/ZeroAPI
 user-invocable: true
-compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Same-provider account steering via `authProfile` works best on OpenClaw runtimes that support `authProfileOverride` from `before_model_resolve`; older runtimes use ZeroAPI's best-effort session-store fallback when the active session already exists.
+compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. OpenClaw v2026.4.20 still only consumes `providerOverride` and `modelOverride` from `before_model_resolve`, so same-provider account steering via `authProfile` uses ZeroAPI's best-effort session-store fallback when the active session already exists.
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw","claude"],"config":["agents"]}}}
 ---
 
@@ -77,7 +77,7 @@ Five subscription or account-quota providers are currently supported by the rout
 | Provider | OpenClaw ID | Auth | Tiers |
 |----------|-------------|------|-------|
 | OpenAI | `openai-codex` | OAuth PKCE via ChatGPT | Plus, Pro |
-| Kimi | `moonshot` (`kimi`, `kimi-coding` aliases) | API key | Moderato, Allegretto, Allegro, Vivace |
+| Kimi | `moonshot` (`kimi`, `kimi-coding` legacy aliases) | API key | Moderato, Allegretto, Allegro, Vivace |
 | Z AI (GLM) | `zai` | API key (`zai-coding-global`) | Lite, Pro, Max |
 | MiniMax | `minimax-portal` (`minimax` alias) | OAuth portal | Starter, Plus, Max, Ultra-HS |
 | Qwen Portal | `qwen-portal` (`qwen`, `qwen-dashscope` aliases) | OAuth portal | Free OAuth |
@@ -206,7 +206,7 @@ Persist the result into a subscription profile with:
   - `research-aware`
   - `speed-aware`
 
-If the user has multiple accounts under the same provider, also build a `subscription_inventory` with one entry per account. Include `authProfile` when the user has matching OpenClaw auth profiles configured. ZeroAPI returns that value as `authProfileOverride` on newer OpenClaw runtimes. Older runtimes use ZeroAPI's best-effort session-store fallback when the active session already exists, and otherwise continue to rely on `auth.order`. For the current account-pool scoring contract, see `references/account-pool-spec.md`.
+If the user has multiple accounts under the same provider, also build a `subscription_inventory` with one entry per account. Include `authProfile` when the user has matching OpenClaw auth profiles configured. ZeroAPI syncs that preferred profile into OpenClaw session state when the active session already exists, and otherwise continues to rely on OpenClaw `auth.order`. For the current account-pool scoring contract, see `references/account-pool-spec.md`.
 
 The user declares what subscriptions they have. ZeroAPI decides routing.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -47,7 +47,7 @@ These examples are intentionally conservative starter pools. `benchmarks.json` t
 |-------|----------|--------------|
 | GPT-5.4 | openai-codex | $5.63 |
 | GLM-5.1 | zai | $1.55 |
-| Kimi K2.5 (Reasoning) | moonshot | $1.20 |
+| Kimi K2.6 (K2.5 benchmark proxy until refresh) | moonshot | $1.71 |
 | MiniMax-M2.7 | minimax-portal | $0.53 |
 | Qwen Portal coder-model | qwen-portal | $1.13 benchmark proxy |
 
@@ -137,7 +137,7 @@ High-risk keywords (`deploy`, `delete`, `drop`, `production`, `credentials`, etc
 
 ## Multi-account note
 
-If you have multiple subscriptions under the same provider, prefer `subscription_inventory` over squeezing them into one `subscription_profile` tier. ZeroAPI uses inventory both for provider headroom scoring and for `authProfileOverride` steering when the winning account declares an `authProfile`. Newer OpenClaw runtimes consume that hook field directly. Older runtimes fall back to ZeroAPI's best-effort session-store sync when the session already exists, and otherwise keep using `auth.order`, cooldowns, and session stickiness.
+If you have multiple subscriptions under the same provider, prefer `subscription_inventory` over squeezing them into one `subscription_profile` tier. ZeroAPI uses inventory both for provider headroom scoring and for `authProfileOverride` steering when the winning account declares an `authProfile`. OpenClaw v2026.4.20 still does not merge that hook field directly, so ZeroAPI uses its best-effort session-store sync when the session already exists, and otherwise keeps using `auth.order`, cooldowns, and session stickiness.
 
 ## Customizing
 

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -66,7 +66,7 @@
         "scicode": 0.438
       }
     },
-    "moonshot/kimi-k2.5": {
+    "moonshot/kimi-k2.6": {
       "context_window": 262144,
       "supports_vision": true,
       "speed_tps": 32.926,
@@ -123,20 +123,20 @@
       "primary": "openai-codex/gpt-5.4",
       "fallbacks": [
         "zai/glm-5.1",
-        "moonshot/kimi-k2.5"
+        "moonshot/kimi-k2.6"
       ]
     },
     "research": {
       "primary": "openai-codex/gpt-5.4",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "minimax-portal/MiniMax-M2.7"
       ]
     },
     "orchestration": {
       "primary": "zai/glm-5.1",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "qwen-portal/coder-model"
       ]
     },

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -58,7 +58,7 @@
         "scicode": 0.438
       }
     },
-    "moonshot/kimi-k2.5": {
+    "moonshot/kimi-k2.6": {
       "context_window": 262144,
       "supports_vision": true,
       "speed_tps": 32.926,
@@ -81,34 +81,34 @@
       "primary": "openai-codex/gpt-5.4",
       "fallbacks": [
         "zai/glm-5.1",
-        "moonshot/kimi-k2.5"
+        "moonshot/kimi-k2.6"
       ]
     },
     "research": {
       "primary": "openai-codex/gpt-5.4",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "zai/glm-5.1"
       ]
     },
     "orchestration": {
       "primary": "zai/glm-5.1",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "openai-codex/gpt-5.4"
       ]
     },
     "math": {
       "primary": "openai-codex/gpt-5.4",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "zai/glm-5.1"
       ]
     },
     "fast": {
       "primary": "zai/glm-5.1",
       "fallbacks": [
-        "moonshot/kimi-k2.5",
+        "moonshot/kimi-k2.6",
         "openai-codex/gpt-5.4"
       ]
     },
@@ -116,7 +116,7 @@
       "primary": "zai/glm-5.1",
       "fallbacks": [
         "zai/glm-5.1",
-        "moonshot/kimi-k2.5"
+        "moonshot/kimi-k2.6"
       ]
     }
   },

--- a/plugin/__tests__/onboarding.test.ts
+++ b/plugin/__tests__/onboarding.test.ts
@@ -41,6 +41,16 @@ describe("buildStarterConfig", () => {
     expect(config.fast_ttft_max_seconds).toBe(8);
   });
 
+  it("uses the current OpenClaw Moonshot default for Kimi starter configs", () => {
+    const config = buildStarterConfig({
+      providers: [{ providerId: "moonshot", tierId: "moderato" }],
+    });
+
+    expect(Object.keys(config.models)).toEqual(["moonshot/kimi-k2.6"]);
+    expect(config.models["moonshot/kimi-k2.6"]?.context_window).toBe(262144);
+    expect(config.routing_rules.default.primary).toBe("moonshot/kimi-k2.6");
+  });
+
   it("prefers inventory for multi-account providers and keeps modifier selection", () => {
     const config = buildStarterConfig({
       providers: [{ providerId: "zai", tierId: "pro" }],

--- a/plugin/onboarding.ts
+++ b/plugin/onboarding.ts
@@ -30,6 +30,7 @@ const STARTER_RUNTIME_META: Record<string, { context_window: number; supports_vi
   "openai-codex/gpt-5.4": { context_window: 272000, supports_vision: false },
   "openai-codex/gpt-5.4-mini": { context_window: 272000, supports_vision: false },
   "zai/glm-5.1": { context_window: 202800, supports_vision: false },
+  "moonshot/kimi-k2.6": { context_window: 262144, supports_vision: true },
   "moonshot/kimi-k2.5": { context_window: 262144, supports_vision: true },
   "minimax-portal/MiniMax-M2.7": { context_window: 204800, supports_vision: true },
   "qwen-portal/coder-model": { context_window: 1000000, supports_vision: false },
@@ -38,9 +39,13 @@ const STARTER_RUNTIME_META: Record<string, { context_window: number; supports_vi
 const STARTER_PROVIDER_MODELS: Record<string, string[]> = {
   "openai-codex": ["openai-codex/gpt-5.4", "openai-codex/gpt-5.4-mini"],
   "zai": ["zai/glm-5.1"],
-  "moonshot": ["moonshot/kimi-k2.5"],
+  "moonshot": ["moonshot/kimi-k2.6"],
   "minimax-portal": ["minimax-portal/MiniMax-M2.7"],
   "qwen-portal": ["qwen-portal/coder-model"],
+};
+
+const STARTER_BENCHMARK_PROXIES: Record<string, string> = {
+  "moonshot/kimi-k2.6": "moonshot/kimi-k2.5",
 };
 
 const DEFAULT_KEYWORDS: Record<string, string[]> = {
@@ -218,20 +223,31 @@ function loadZeroAPIVersion(): string {
   return pkg.version;
 }
 
-function getStarterBenchmarkRecord(snapshot: BenchmarkSnapshot, modelKey: string): BenchmarkRecord {
+function findStarterBenchmarkRecord(snapshot: BenchmarkSnapshot, modelKey: string): BenchmarkRecord | undefined {
   const slashIndex = modelKey.indexOf("/");
   const providerId = modelKey.slice(0, slashIndex);
   const modelId = modelKey.slice(slashIndex + 1);
 
-  const record = snapshot.models.find((item) =>
+  return snapshot.models.find((item) =>
     item.openclaw_provider === providerId && item.openclaw_model === modelId,
   );
+}
 
-  if (!record) {
-    throw new Error(`Missing benchmark data for starter model ${modelKey}`);
+function getStarterBenchmarkRecord(snapshot: BenchmarkSnapshot, modelKey: string): BenchmarkRecord {
+  const record = findStarterBenchmarkRecord(snapshot, modelKey);
+  if (record) {
+    return record;
   }
 
-  return record;
+  const proxyModelKey = STARTER_BENCHMARK_PROXIES[modelKey];
+  if (proxyModelKey) {
+    const proxyRecord = findStarterBenchmarkRecord(snapshot, proxyModelKey);
+    if (proxyRecord) {
+      return proxyRecord;
+    }
+  }
+
+  throw new Error(`Missing benchmark data for starter model ${modelKey}`);
 }
 
 function buildStarterModels(snapshot: BenchmarkSnapshot, providerIds: string[]): Record<string, ModelCapabilities> {

--- a/policy-families.json
+++ b/policy-families.json
@@ -39,17 +39,20 @@
       "provider": "moonshot",
       "label": "Kimi K2 core family",
       "openclaw_model_ids": [
+        "kimi-k2.6",
         "kimi-k2.5",
         "kimi-k2-thinking",
         "kimi-k2-thinking-turbo",
         "kimi-k2-turbo"
       ],
       "benchmark_slugs": [
+        "kimi-k2-6",
         "kimi-k2-5",
         "kimi-k2-thinking",
         "kimi-k2-thinking-turbo",
         "kimi-k2-turbo"
-      ]
+      ],
+      "notes": "OpenClaw v2026.4.20 defaults Moonshot to kimi-k2.6. Starter configs use kimi-k2.5 benchmark values as a transparent proxy until Artificial Analysis publishes a matching kimi-k2-6 row."
     },
     {
       "id": "minimax-m27-core",

--- a/references/account-pool-spec.md
+++ b/references/account-pool-spec.md
@@ -165,8 +165,8 @@ If the winning account defines `authProfile`, ZeroAPI passes that forward as the
 
 Current behavior:
 
-- newer OpenClaw runtimes can consume `authProfileOverride` directly
-- older runtimes use ZeroAPI's best-effort session-store compatibility fallback when possible
+- OpenClaw v2026.4.20 still does not merge `authProfileOverride` from `before_model_resolve`
+- ZeroAPI uses its best-effort session-store compatibility fallback when possible
 - user-pinned auth profiles still win
 
 This means same-provider reroutes can still be meaningful even when the provider and model stay the same.

--- a/references/cron-config.md
+++ b/references/cron-config.md
@@ -27,6 +27,11 @@ npm run cron:apply -- --openclaw-dir ~/.openclaw --yes
 
 `cron:apply` is dry-run by default. With `--yes`, it writes a timestamped backup next to `jobs.json` before patching eligible `agentTurn` jobs. It skips low-confidence changes unless `--include-low-confidence` is passed, and `--job-id <id>` can scope the write to selected jobs.
 
+OpenClaw v2026.4.20 splits cron runtime state into `jobs-state.json`. ZeroAPI
+intentionally reads and patches only the job definition store (`jobs.json` or
+the configured `cron.store`). It must not copy, edit, or version-control
+`jobs-state.json`; that file is runtime-owned.
+
 | Cron Task Type | Detection Signal | Model Criteria |
 |---------------|------------------|----------------|
 | Health check / status | Reads file, checks thresholds | Cheapest fast model, low TTFT |
@@ -63,8 +68,8 @@ Example fallback chains (5-provider setup):
 
 | Category | Primary | Fallback 1 | Fallback 2 | Fallback 3 |
 |----------|---------|------------|------------|------------|
-| Code | GPT-5.4 (OpenAI) | GLM-5.1 (Z AI) | Kimi K2.5 (Kimi) | MiniMax-M2.7 (MiniMax) |
-| Research | GPT-5.4 (OpenAI) | MiniMax-M2.7 (MiniMax) | Kimi K2.5 (Kimi) | Qwen Portal (Qwen proxy) |
-| Orchestration | GLM-5.1 (Z AI) | Kimi K2.5 (Kimi) | Qwen Portal (Qwen proxy) | — |
+| Code | GPT-5.4 (OpenAI) | GLM-5.1 (Z AI) | Kimi K2.6 (Kimi) | MiniMax-M2.7 (MiniMax) |
+| Research | GPT-5.4 (OpenAI) | MiniMax-M2.7 (MiniMax) | Kimi K2.6 (Kimi) | Qwen Portal (Qwen proxy) |
+| Orchestration | GLM-5.1 (Z AI) | Kimi K2.6 (Kimi) | Qwen Portal (Qwen proxy) | — |
 | Math | GPT-5.4 (OpenAI) | GLM-5.1 (Z AI) | Qwen Portal (Qwen proxy) | — |
-| Fast | GLM-5.1 (Z AI) | MiniMax-M2.7 (MiniMax) | Kimi K2.5 (Kimi) | — |
+| Fast | GLM-5.1 (Z AI) | MiniMax-M2.7 (MiniMax) | Kimi K2.6 (Kimi) | — |

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -94,11 +94,21 @@ openclaw models auth login --provider openai-codex
 openclaw onboard --auth-choice moonshot-api-key
 ```
 
+OpenClaw v2026.4.20 makes `moonshot/kimi-k2.6` the default Moonshot Kimi route.
+ZeroAPI starter configs follow that runtime default. The committed Artificial
+Analysis snapshot may briefly proxy K2.6 scoring through K2.5 until the weekly
+benchmark refresh includes a native K2.6 row.
+
+Important: OpenClaw treats Moonshot K2 (`moonshot/...`) and Kimi Coding
+(`kimi/...`) as separate providers with separate keys and model refs. ZeroAPI's
+`kimi` / `kimi-coding` aliases are retained only for legacy config compatibility.
+
 **Models**:
 
 | Model ID | Notes |
 |----------|-------|
-| `kimi-k2.5` | Flagship |
+| `kimi-k2.6` | Current OpenClaw default |
+| `kimi-k2.5` | Previous flagship |
 | `kimi-k2-thinking` | Extended reasoning |
 
 **Provider entry** (in `openclaw.json`):
@@ -111,6 +121,7 @@ openclaw onboard --auth-choice moonshot-api-key
         "baseUrl": "https://api.moonshot.ai/v1",
         "api": "openai-completions",
         "models": [
+          { "id": "kimi-k2.6" },
           { "id": "kimi-k2.5" },
           { "id": "kimi-k2-thinking" }
         ]
@@ -318,7 +329,7 @@ This file is not the runtime source of truth for OpenClaw itself. Think of it as
 | `benchmarks_date` | Date of the embedded benchmarks.json used to generate this config |
 | `subscription_catalog_version` | Public tier catalog version used when the config was generated |
 | `subscription_profile.global` | Enabled providers and selected subscription tiers. Missing or empty values can filter out all routing candidates. |
-| `subscription_inventory.accounts` | Preferred same-provider multi-account pool. Each account can declare `provider`, `tierId`, `authProfile`, `usagePriority`, and `intendedUse`. Winning accounts pass `authProfile` through as OpenClaw `authProfileOverride` on newer runtimes, while older runtimes use ZeroAPI's best-effort session-store fallback when possible and otherwise keep using `auth.order`. `intendedUse` is a soft scoring preference, not a hard filter. See [`account-pool-spec.md`](account-pool-spec.md) for the exact scoring and tie-break rules. |
+| `subscription_inventory.accounts` | Preferred same-provider multi-account pool. Each account can declare `provider`, `tierId`, `authProfile`, `usagePriority`, and `intendedUse`. Winning accounts pass `authProfile` through as OpenClaw `authProfileOverride` for forward compatibility, but OpenClaw v2026.4.20 still uses ZeroAPI's best-effort session-store fallback when possible and otherwise keeps using `auth.order`. `intendedUse` is a soft scoring preference, not a hard filter. See [`account-pool-spec.md`](account-pool-spec.md) for the exact scoring and tie-break rules. |
 | `default_model` | ZeroAPI's preferred default policy target. If `openclaw.json` differs, OpenClaw runtime default still wins unless a per-turn override is returned. |
 | `routing_modifier` | Optional task-aware overlay on top of `routing_mode: "balanced"`. Valid values: `coding-aware`, `research-aware`, `speed-aware`. See [`routing-modifiers-spec.md`](routing-modifiers-spec.md). |
 | `external_model_policy` | How ZeroAPI behaves when the active current model is outside its own `models` pool. `stay` keeps that foreign or external model. `allow` lets ZeroAPI re-enter and route back into its subscription pool. |

--- a/references/routing-policy-spec.md
+++ b/references/routing-policy-spec.md
@@ -190,8 +190,8 @@ When `subscription_inventory` resolves a preferred account:
 If the winning model equals the current model:
 
 - ZeroAPI still routes when `preferredAuthProfile` is present
-- newer OpenClaw runtimes consume `authProfileOverride` directly
-- older runtimes rely on ZeroAPI's best-effort session-store fallback
+- OpenClaw v2026.4.20 still consumes only `providerOverride` and `modelOverride` from `before_model_resolve`
+- ZeroAPI relies on its best-effort session-store fallback for same-provider account steering when the active session exists
 
 Guardrail:
 


### PR DESCRIPTION
## Summary
- switch Kimi starter configs and examples to OpenClaw v2026.4.20's `moonshot/kimi-k2.6` default
- keep K2.5 benchmark values as an explicit temporary proxy until the benchmark refresh has native K2.6 data
- document the new cron `jobs-state.json` split and correct same-provider auth-profile steering docs

## Why
OpenClaw v2026.4.20 changed the practical Moonshot default, split cron runtime state out of `jobs.json`, and still does not merge `authProfileOverride` from `before_model_resolve`. ZeroAPI should match those runtime contracts instead of carrying stale K2.5/default and auth-profile wording.

## Tests
- `npm test`
- JSON parse check for `policy-families.json`, `examples/openai-glm-kimi.json`, and `examples/full-stack.json`
- grep check for stale direct-authProfile wording

## Non-goals
- no live benchmark refresh in this PR
- no change to OpenClaw provider auth or runtime hook behavior