### PR TITLE
chore(release): prepare 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-04-22
+
 ### Changed
 - Aligned Kimi starter configs and examples with OpenClaw v2026.4.20's `moonshot/kimi-k2.6` default, while using the committed K2.5 benchmark row as an explicit temporary proxy until the benchmark refresh includes native K2.6 data.
 - Documented OpenClaw's new cron `jobs-state.json` split so ZeroAPI cron helpers keep patching job definitions only and never touch runtime state.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.4.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.7.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.7.0)
+[![Version](https://img.shields.io/badge/version-3.7.1-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.7.1)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.7.0
+version: 3.7.1
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when user mentions model routing, multi-model setup, "which model should I use",
@@ -12,7 +12,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Op
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw","claude"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.7.0 - Plugin-Based Model Routing
+# ZeroAPI v3.7.1 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -228,7 +228,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.0.0",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -8,7 +8,7 @@ import { syncSessionAuthProfileOverride } from "./session-auth.js";
 import { startSubscriptionAdvisoryMonitor } from "./subscription-advisory.js";
 import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 
-const PLUGIN_VERSION = "3.7.0";
+const PLUGIN_VERSION = "3.7.1";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Balanced benchmark-aware model routing across subscription providers",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-router",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "private": true,
   "description": "ZeroAPI — balanced benchmark-aware routing for OpenClaw",
   "type": "module",

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -256,7 +256,7 @@ This file is not the runtime source of truth for OpenClaw itself. Think of it as
 
 ```json
 {
-  "version": "3.7.0",
+  "version": "3.7.1",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<YYYY-MM-DD>",
   "subscription_catalog_version": "1.0.0",


### PR DESCRIPTION
## Summary
- Bumps ZeroAPI package/plugin/docs metadata to 3.7.1 after the OpenClaw v2026.4.20 compatibility fix.
- Moves the OpenClaw v2026.4.20 compatibility changelog notes under a dated 3.7.1 section.
- Keeps example config and SKILL version fields aligned with the release badge.

## Why
- The compatibility update landed after 3.7.0, so users should see a clean patch release marker instead of main-only docs drift.

## Tests
- npm test
- JSON parse check for package, plugin, and example config files
- rg old-version check, with only the historical 3.7.0 changelog heading remaining

## Non-goals
- No runtime routing behavior changes beyond the already merged OpenClaw v2026.4.20 compatibility PR.