### PR TITLE
fix: unref advisory monitor handles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.7.2] - 2026-04-22
+
+### Fixed
+- Unref subscription advisory file watchers and debounce timers so OpenClaw CLI diagnostics such as `openclaw hooks check --json` can exit cleanly after loading the plugin.
+
 ## [3.7.1] - 2026-04-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.4.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.7.1-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.7.1)
+[![Version](https://img.shields.io/badge/version-3.7.2-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.7.2)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.7.1
+version: 3.7.2
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when user mentions model routing, multi-model setup, "which model should I use",
@@ -12,7 +12,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Op
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw","claude"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.7.1 - Plugin-Based Model Routing
+# ZeroAPI v3.7.2 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -228,7 +228,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.0.0",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "2026-04-18T00:00:00Z",
   "benchmarks_date": "2026-04-18",
   "subscription_catalog_version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/__tests__/subscription-advisory-monitor.test.ts
+++ b/plugin/__tests__/subscription-advisory-monitor.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ZeroAPIConfig } from "../types.js";
+
+const watchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    watch: watchMock,
+  };
+});
+
+import { startSubscriptionAdvisoryMonitor } from "../subscription-advisory.js";
+
+function buildConfig(): ZeroAPIConfig {
+  return {
+    version: "3.7.2",
+    generated: "2026-04-22T00:00:00.000Z",
+    benchmarks_date: "2026-04-19",
+    default_model: "zai/glm-5.1",
+    routing_mode: "balanced",
+    models: {},
+    routing_rules: {},
+    keywords: {},
+    high_risk_keywords: [],
+    fast_ttft_max_seconds: 5,
+    workspace_hints: {},
+  };
+}
+
+describe("subscription advisory monitor", () => {
+  let openclawDir: string;
+
+  beforeEach(() => {
+    openclawDir = mkdtempSync(join(tmpdir(), "zeroapi-monitor-"));
+    watchMock.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    rmSync(openclawDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it("unrefs file watchers and debounce timers so CLI diagnostics can exit", () => {
+    mkdirSync(join(openclawDir, "agents"), { recursive: true });
+    writeFileSync(
+      join(openclawDir, "openclaw.json"),
+      JSON.stringify({ models: { providers: { "openai-codex": {} } } }),
+    );
+
+    const callbacks: Array<(eventType: string, filename?: string) => void> = [];
+    const watchers: Array<{ close: ReturnType<typeof vi.fn>; unref: ReturnType<typeof vi.fn> }> = [];
+    watchMock.mockImplementation(
+      (_path: string, callback: (eventType: string, filename?: string) => void) => {
+        callbacks.push(callback);
+        const watcher = {
+          close: vi.fn(),
+          unref: vi.fn(),
+        };
+        watchers.push(watcher);
+        return watcher;
+      },
+    );
+
+    const timeoutUnref = vi.fn();
+    const realSetTimeout = globalThis.setTimeout;
+    vi.spyOn(globalThis, "setTimeout").mockImplementation(
+      ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+        const timer = realSetTimeout(handler, timeout, ...args) as NodeJS.Timeout;
+        const realUnref = timer.unref?.bind(timer);
+        timer.unref = vi.fn(() => {
+          timeoutUnref();
+          realUnref?.();
+          return timer;
+        }) as NodeJS.Timeout["unref"];
+        return timer;
+      }) as typeof setTimeout,
+    );
+
+    const handle = startSubscriptionAdvisoryMonitor({
+      config: buildConfig(),
+      logger: { info: vi.fn(), warn: vi.fn() },
+      openclawDir,
+    });
+
+    expect(watchers.length).toBeGreaterThan(0);
+    for (const watcher of watchers) {
+      expect(watcher.unref).toHaveBeenCalledTimes(1);
+    }
+
+    callbacks[0]?.("change", "openclaw.json");
+    expect(timeoutUnref).toHaveBeenCalledTimes(1);
+
+    handle.stop();
+  });
+});

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -8,7 +8,7 @@ import { syncSessionAuthProfileOverride } from "./session-auth.js";
 import { startSubscriptionAdvisoryMonitor } from "./subscription-advisory.js";
 import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 
-const PLUGIN_VERSION = "3.7.1";
+const PLUGIN_VERSION = "3.7.2";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Balanced benchmark-aware model routing across subscription providers",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "configSchema": {
     "type": "object",
     "additionalProperties": false,

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-router",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "private": true,
   "description": "ZeroAPI — balanced benchmark-aware routing for OpenClaw",
   "type": "module",

--- a/plugin/subscription-advisory.ts
+++ b/plugin/subscription-advisory.ts
@@ -440,11 +440,13 @@ function safeWatch(
   logger: MonitorLogger,
 ): FSWatcher | null {
   try {
-    return watch(targetPath, (eventType, filename) => {
+    const watcher = watch(targetPath, (eventType, filename) => {
       if (eventType === "rename" || eventType === "change") {
         onChange(filename);
       }
     });
+    watcher.unref?.();
+    return watcher;
   } catch (error) {
     logger.warn(`ZeroAPI advisory watcher failed for ${targetPath}: ${String(error)}`);
     return null;
@@ -551,6 +553,7 @@ export function startSubscriptionAdvisoryMonitor(params: {
       clearTimeout(debounceTimer);
     }
     debounceTimer = setTimeout(runRefresh, ADVISORY_DEBOUNCE_MS);
+    debounceTimer.unref?.();
   };
 
   const rootWatcher = safeWatch(

--- a/references/provider-config.md
+++ b/references/provider-config.md
@@ -256,7 +256,7 @@ This file is not the runtime source of truth for OpenClaw itself. Think of it as
 
 ```json
 {
-  "version": "3.7.1",
+  "version": "3.7.2",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<YYYY-MM-DD>",
   "subscription_catalog_version": "1.0.0",


### PR DESCRIPTION
## Summary
- Unrefs ZeroAPI advisory file watchers and debounce timers.
- Adds a regression test that verifies watcher and timer handles are unrefed.
- Prepares patch release metadata for v3.7.2.

## Why
- OpenClaw CLI diagnostics such as `openclaw hooks check --json` load hook-only plugins to inspect them. ZeroAPI v3.7.1 started advisory watchers during plugin registration, which could keep short-lived CLI diagnostics alive after JSON output was produced.

## Tests
- npm test
- JSON parse check
- old version grep, with only historical changelog headings remaining

## Non-goals
- No routing policy changes.
- No OpenClaw runtime patch changes in this PR.