### PR TITLE
Quality follow-ups: cron/agent-audit fixes, vision frontier, script coverage, CI hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions (test, secret-scan, publish, refresh)
+  # current: Dependabot opens PRs that bump each pin forward and rewrites the
+  # trailing `# vX.Y.Z` comment, so pinning to an immutable commit no longer
+  # means missing security patches.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/publish-clawhub-plugin.yml
+++ b/.github/workflows/publish-clawhub-plugin.yml
@@ -15,14 +15,22 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Generous bound: the downstream install smoke test retries up to 10x at 300s
+    # each (~52min worst case), so a lower cap would false-fail a slow-but-valid
+    # publish. It still stops a genuinely wedged job well under the 6h default.
+    timeout-minutes: 60
     env:
       CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
       CLAWHUB_CLI_VERSION: "0.12.2"
+      # Intentionally "latest": this is a post-publish smoke test whose job is to
+      # confirm the freshly published plugin installs under the OpenClaw users
+      # actually have now. Pinning would let it pass against a stale binary while
+      # real installs break.
       OPENCLAW_VERIFY_VERSION: "latest"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
 

--- a/.github/workflows/refresh-benchmarks.yml
+++ b/.github/workflows/refresh-benchmarks.yml
@@ -15,14 +15,15 @@ concurrency:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       AA_API_KEY: ${{ secrets.AA_API_KEY }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,8 +10,9 @@ jobs:
   gitleaks:
     name: Gitleaks Secret Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
       # Pinned to the immutable commit the v2 tag resolves to (v2.3.9) so a moved or

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,15 +9,19 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         node-version: [20, 22]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      # First-party actions pinned to immutable commit SHAs (a moved/compromised
+      # major tag could run unreviewed code on jobs holding GITHUB_TOKEN). The
+      # github-actions Dependabot config (.github/dependabot.yml) bumps these.
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
       - run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@
 - Remove a stray NUL byte accidentally introduced into `plugin/classifier.ts` (a regex cache-key
   separator) that made git treat the file as binary — hiding its line-level diffs and excluding it
   from `git diff --check`.
+- `applyCronAuditPatches` now pairs each report item to its job by stable id instead of array
+  position, so a caller that filters or reorders the jobs array between audit and apply can no
+  longer patch the wrong cron job's payload (same-id duplicates still dequeue in order).
+- Agent workspace-hint inference now prefers the pattern matched by the agent id over incidental
+  words in its name/description, so an agent whose id encodes its role (e.g. `monitor`, `ops-*`,
+  `status-*`) is no longer mis-hinted by an earlier-declared pattern that only matched a stray
+  description word (e.g. "content", "deploy").
+- Make `integrations/hermes/vision_aux.py` import its sibling `router` package-relative with an
+  absolute fallback, so it loads both as a top-level script (the test/README path) and as a
+  package submodule (`hermes.vision_aux`), which previously crashed with `ModuleNotFoundError`.
+- `scripts/refresh_benchmarks.py` now sources the round-tripped `benchmark_categories` block from
+  the `--output` target being refreshed (with a safe fallback) instead of always reading the
+  hardcoded repo `benchmarks.json`, which also avoids a `FileNotFoundError` on first run to a new
+  path. Default runs (no `--output`) are byte-identical.
 
 ### Changed
 - Cache compiled keyword regexes on the routing hot path (classifier, vision/continuation scans,
@@ -42,6 +56,12 @@
   `set -o pipefail`) and add `ZEROAPI_DOCTOR_SKIP_RUNTIME` for deterministic runs.
 - CI: use `npm ci` for reproducible installs, pin Python via `actions/setup-python`, and pin
   `gitleaks/gitleaks-action` to an immutable commit SHA (v2.3.9).
+- CI hardening: pin every first-party GitHub Action (`actions/checkout`, `actions/setup-node`,
+  `actions/setup-python`) to an immutable commit SHA across all four workflows, add a
+  `github-actions` Dependabot config so those pins are bumped forward automatically, and give every
+  job an explicit `timeout-minutes` so a hung step cannot run to the 6-hour default. The publish
+  smoke test deliberately keeps `OPENCLAW_VERIFY_VERSION: latest` (it validates installs against
+  the OpenClaw users have now, not a frozen binary).
 - Correct stale product-contract docs: high-risk keywords are diagnostic-only and never block or
   downgrade routing (`routing-policy-spec.md`, `routing-modifiers-spec.md`), and reconcile the
   benchmark-staleness thresholds in `risk-policy.md` with `benchmark-governance.md`.
@@ -51,6 +71,14 @@
   simulator output (`includeDiagnostics` only; never computed on the runtime path), fulfilling the
   explainability-contract "next extension". A fixture-backed doctor smoke test and route-state unit
   tests were added.
+- Extend the frontier diagnostic to the vision-capability-escape route so a screenshot/image turn
+  exposes the same per-candidate detail as a normal route (still `includeDiagnostics`-only via a new
+  `rankSubscriptionWeightedCandidatesFromPool`; the runtime image path is unchanged).
+- Test coverage for previously-untested developer tooling: `scripts/eval.ts` (pure helpers
+  extracted to a side-effect-free `scripts/eval-lib.mjs` and unit-tested), and subprocess
+  regression tests for `scripts/simulate.ts` and `scripts/compare_modifiers.ts` driven against the
+  committed fixture. Added regression tests for cron id-pairing, agent-audit id-priority hinting,
+  the `vision_aux` package import, and `refresh_benchmarks --output` category sourcing.
 
 ## [3.8.36] - 2026-05-28
 

--- a/integrations/hermes/test_vision_aux.py
+++ b/integrations/hermes/test_vision_aux.py
@@ -1,4 +1,6 @@
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -131,6 +133,27 @@ class HermesVisionAuxiliaryConfigTest(unittest.TestCase):
             self.assertTrue(result["changed"])
             self.assertTrue(text.endswith("    timeout: 120\n"))
             self.assertIn("auxiliary:\n  vision:\n    provider: openai-codex\n    model: gpt-5.5", text)
+
+    def test_importable_as_package_submodule(self):
+        # vision_aux must resolve its sibling `router` whether it is loaded as a
+        # top-level script module (this test, README invocation) OR as a package
+        # submodule (`hermes.vision_aux`). The latter used to crash with
+        # ModuleNotFoundError: No module named 'router'.
+        integrations_dir = Path(__file__).resolve().parents[1]  # .../integrations
+        code = (
+            "import hermes.vision_aux as m;"
+            "assert hasattr(m, 'configure_auxiliary_vision');"
+            "assert hasattr(m, 'resolve_auxiliary_vision_route');"
+            "print('ok')"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(integrations_dir),
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("ok", result.stdout)
 
     def test_no_change_when_no_vision_route_is_needed(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/integrations/hermes/vision_aux.py
+++ b/integrations/hermes/vision_aux.py
@@ -19,7 +19,10 @@ import json
 from pathlib import Path
 from typing import Any
 
-from router import ZeroAPIRouter, load_config
+try:
+    from .router import ZeroAPIRouter, load_config
+except ImportError:  # pragma: no cover - standalone/script invocation
+    from router import ZeroAPIRouter, load_config
 
 VISION_PROBE_PROMPT = "Please inspect the attached screenshot."
 

--- a/plugin/__tests__/agent-audit.test.ts
+++ b/plugin/__tests__/agent-audit.test.ts
@@ -114,6 +114,26 @@ describe("agent model audit", () => {
     });
   });
 
+  it("prefers the agent id signal over incidental name/description words", () => {
+    expect(inferWorkspaceHintsFromOpenClawConfig({
+      agents: {
+        list: [
+          // id encodes an ops/monitor role, but the description carries "content"
+          // (P1 social) and "deploy" (P2 code) which would win under first-match.
+          { id: "ops-monitor", name: "Ops Monitor", description: "Tracks deploy status and content health" },
+          // id is literally "monitor" (P4 ops), description has "build" (P2 code).
+          { id: "monitor", name: "Build Monitor", description: "Watches CI build status" },
+          // id has no recognized token, so the name+description fallback applies.
+          { id: "helper", description: "engage with content" },
+        ],
+      },
+    })).toEqual({
+      "ops-monitor": ["orchestration", "fast"],
+      monitor: ["orchestration", "fast"],
+      helper: ["research", "code"],
+    });
+  });
+
   it("adds missing catalog entries and baselines routed agents only", () => {
     const openclawConfig = {
       agents: {

--- a/plugin/__tests__/cron-apply.test.ts
+++ b/plugin/__tests__/cron-apply.test.ts
@@ -107,4 +107,40 @@ describe("applyCronAuditPatches", () => {
     expect(result.applied.map((item) => item.id)).toEqual(["low-confidence"]);
     expect(result.skipped).toContainEqual(expect.objectContaining({ id: "safe-change", reason: "skip:not_selected" }));
   });
+
+  it("pairs each job with its own report item by id, not array position", () => {
+    // Report items in REVERSE order relative to jobs: positional pairing would
+    // apply low-confidence's decision to the safe-change job and vice versa.
+    const reversedReport: CronAuditReport = { ...report, items: [report.items[1], report.items[0]] };
+    const result = applyCronAuditPatches(jobs, reversedReport);
+
+    // safe-change (jobs[0]) must still be the one that gets applied (its own item is
+    // high-confidence), and its patched payload must come from its own item.
+    expect(result.applied.map((item) => item.id)).toEqual(["safe-change"]);
+    expect(result.jobs[0].payload).toMatchObject({
+      kind: "agentTurn",
+      model: "openai-codex/gpt-5.4",
+      fallbacks: ["zai/glm-5.1"],
+    });
+    // low-confidence (jobs[1]) is still skipped as low-confidence, not mis-applied.
+    expect(result.skipped).toContainEqual(
+      expect.objectContaining({ id: "low-confidence", reason: "skip:low_confidence" }),
+    );
+    expect(result.jobs[1].payload).toMatchObject({ model: "zai/glm-5.1" });
+  });
+
+  it("matches the surviving job by id when the jobs array is filtered", () => {
+    // Only the second job survives, but the report still describes both jobs.
+    const filteredJobs = [jobs[1]];
+    const result = applyCronAuditPatches(filteredJobs, report, { includeLowConfidence: true });
+
+    // The surviving job must be paired with ITS OWN item (low-confidence), not jobs[0]'s.
+    expect(result.applied.map((item) => item.id)).toEqual(["low-confidence"]);
+    expect(result.jobs).toHaveLength(1);
+    expect(result.jobs[0].payload).toMatchObject({
+      kind: "agentTurn",
+      model: "openai-codex/gpt-5.4",
+      fallbacks: ["zai/glm-5.1"],
+    });
+  });
 });

--- a/plugin/__tests__/decision.test.ts
+++ b/plugin/__tests__/decision.test.ts
@@ -478,6 +478,30 @@ describe("resolveRoutingDecision", () => {
       expect(result.selectedModel).toBe("openai-codex/gpt-5.5");
     });
 
+    it("exposes the frontier on a vision-escape route only under includeDiagnostics", () => {
+      const runtime = resolveRoutingDecision(visionConfig, {
+        prompt: "what does this screenshot show",
+        currentModel: "zai/glm-5",
+      });
+      // The runtime image path must not compute the explainability frontier.
+      expect(runtime.frontier).toBeUndefined();
+
+      const diagnostic = resolveRoutingDecision(visionConfig, {
+        prompt: "what does this screenshot show",
+        currentModel: "zai/glm-5",
+        includeDiagnostics: true,
+      });
+      expect(diagnostic.action).toBe("route");
+      expect(diagnostic.reason).toBe("vision_capability_escape");
+      expect(Array.isArray(diagnostic.frontier)).toBe(true);
+      expect(diagnostic.frontier!.length).toBeGreaterThan(0);
+      // The chosen model must be the top of the exposed frontier, and the entries
+      // must carry the RankedCandidate detail the explainability contract describes.
+      expect(diagnostic.frontier![0].candidate).toBe(diagnostic.selectedModel);
+      expect(typeof diagnostic.frontier![0].benchmarkStrength).toBe("number");
+      expect(typeof diagnostic.frontier![0].withinFrontier).toBe("boolean");
+    });
+
     it("does not escape when current model already supports vision", () => {
       const result = resolveRoutingDecision(visionConfig, {
         prompt: "what does this screenshot show",

--- a/plugin/agent-audit.ts
+++ b/plugin/agent-audit.ts
@@ -125,7 +125,14 @@ export function inferWorkspaceHintsFromOpenClawConfig(openclawConfig: OpenClawCo
       normalizeString(agent.name),
       normalizeString(agent.description),
     ].filter(Boolean).join(" ");
-    const match = TOOL_HEAVY_HINTS.find((hint) => hint.pattern.test(haystack));
+    // Prefer the pattern matched by the agent ID itself (the strongest, most
+    // deliberate signal); only fall back to scanning name+description when the ID
+    // carries no recognized token. This stops incidental description words (e.g.
+    // "content", "build") from overriding an agent whose ID encodes its role
+    // (e.g. "monitor", "ops-*", "status-*").
+    const match =
+      TOOL_HEAVY_HINTS.find((hint) => hint.pattern.test(id)) ??
+      TOOL_HEAVY_HINTS.find((hint) => hint.pattern.test(haystack));
     if (match) {
       hints[id] = match.categories;
     }

--- a/plugin/cron-apply.ts
+++ b/plugin/cron-apply.ts
@@ -1,4 +1,4 @@
-import type { CronAuditJob, CronAuditReport } from "./cron-audit.js";
+import type { CronAuditItem, CronAuditJob, CronAuditReport } from "./cron-audit.js";
 
 type UnknownRecord = Record<string, unknown>;
 
@@ -32,6 +32,13 @@ function normalizeJobIds(jobIds: string[] | undefined): Set<string> | null {
   return new Set(jobIds.map((id) => id.trim()).filter(Boolean));
 }
 
+// Mirror cron-audit's buildItemBase id derivation (cron-audit.ts:360) so a job is
+// paired with the report item that actually describes it.
+function jobKey(job: CronAuditJob): string {
+  const id = typeof job.id === "string" ? job.id.trim() : "";
+  return id || "(unknown)";
+}
+
 export function applyCronAuditPatches(
   jobs: CronAuditJob[],
   report: CronAuditReport,
@@ -41,8 +48,18 @@ export function applyCronAuditPatches(
   const applied: CronApplyDecision[] = [];
   const skipped: CronApplyDecision[] = [];
 
-  const nextJobs = jobs.map((job, index) => {
-    const item = report.items[index];
+  // Pair report items to jobs by stable id rather than array position so a caller
+  // that filters/reorders jobs between audit and apply cannot patch the wrong job.
+  // Same-id duplicates dequeue in order, preserving the well-formed common path.
+  const itemsById = new Map<string, CronAuditItem[]>();
+  for (const item of report.items) {
+    const queue = itemsById.get(item.id) ?? [];
+    queue.push(item);
+    itemsById.set(item.id, queue);
+  }
+
+  const nextJobs = jobs.map((job) => {
+    const item = itemsById.get(jobKey(job))?.shift();
     if (!item) return job;
 
     const decisionBase = {

--- a/plugin/decision.ts
+++ b/plugin/decision.ts
@@ -2,7 +2,7 @@ import { classifyTask } from "./classifier.js";
 import { filterCapableModels, estimateTokens, getCapabilityFilterFailure } from "./filter.js";
 import type { CapabilityFilterFailure } from "./filter.js";
 import { isModelAllowedBySubscriptions, resolveProviderCapacity } from "./inventory.js";
-import { getSubscriptionWeightedCandidates, getSubscriptionWeightedCandidatesFromPool, rankSubscriptionWeightedCandidates } from "./router.js";
+import { getSubscriptionWeightedCandidates, getSubscriptionWeightedCandidatesFromPool, rankSubscriptionWeightedCandidates, rankSubscriptionWeightedCandidatesFromPool } from "./router.js";
 import type { RankedCandidate } from "./router.js";
 import { selectModel } from "./selector.js";
 import { getCanonicalOpenClawProviderId } from "./subscriptions.js";
@@ -445,15 +445,31 @@ export function resolveRoutingDecision(
         .filter(([modelKey]) => isModelEligibleBySubscriptions(config, modelKey, agentId)));
 
       if (Object.keys(visionCapable).length > 0) {
-        const rankedVision = getSubscriptionWeightedCandidatesFromPool(
-          "default",
-          visionCapable,
-          config.subscription_profile,
-          config.subscription_inventory,
-          agentId,
-          config.routing_mode ?? "balanced",
-          config.routing_modifier,
-        );
+        // Frontier detail is explainability-only: compute the rich ranking solely
+        // under includeDiagnostics so the runtime image path still pays only for the
+        // string ordering it needs to pick a target (preserves the <1ms guarantee).
+        const visionFrontier: RankedCandidate[] | undefined = includeDiagnostics
+          ? rankSubscriptionWeightedCandidatesFromPool(
+              "default",
+              visionCapable,
+              config.subscription_profile,
+              config.subscription_inventory,
+              agentId,
+              config.routing_mode ?? "balanced",
+              config.routing_modifier,
+            )
+          : undefined;
+        const rankedVision = visionFrontier
+          ? visionFrontier.map((item) => item.candidate)
+          : getSubscriptionWeightedCandidatesFromPool(
+              "default",
+              visionCapable,
+              config.subscription_profile,
+              config.subscription_inventory,
+              agentId,
+              config.routing_mode ?? "balanced",
+              config.routing_modifier,
+            );
         const ordered = rankedVision.length > 0 ? rankedVision : Object.keys(visionCapable);
 
         const targetModel = ordered[0];
@@ -484,6 +500,7 @@ export function resolveRoutingDecision(
             capabilityRejected: [],
             subscriptionRejected: [],
             weightedCandidates: ordered,
+            frontier: visionFrontier,
             rawDecision,
             finalDecision,
             selectedModel: targetModel,

--- a/plugin/router.ts
+++ b/plugin/router.ts
@@ -369,7 +369,7 @@ export function getSubscriptionWeightedCandidates(
   ).map((item) => item.candidate);
 }
 
-export function getSubscriptionWeightedCandidatesFromPool(
+export function rankSubscriptionWeightedCandidatesFromPool(
   category: TaskCategory,
   availableModels: Record<string, ModelCapabilities>,
   profile: SubscriptionProfile | undefined,
@@ -377,7 +377,7 @@ export function getSubscriptionWeightedCandidatesFromPool(
   agentId: string | undefined,
   routingMode: RoutingMode = "balanced",
   routingModifier?: RoutingModifier,
-): string[] {
+): RankedCandidate[] {
   const candidates = Object.keys(availableModels);
   if (candidates.length === 0) return [];
 
@@ -386,7 +386,7 @@ export function getSubscriptionWeightedCandidatesFromPool(
     fallbacks: candidates.slice(1),
   };
 
-  return getSubscriptionWeightedCandidates(
+  return rankSubscriptionWeightedCandidates(
     category,
     availableModels,
     {
@@ -399,4 +399,24 @@ export function getSubscriptionWeightedCandidatesFromPool(
     routingMode,
     routingModifier,
   );
+}
+
+export function getSubscriptionWeightedCandidatesFromPool(
+  category: TaskCategory,
+  availableModels: Record<string, ModelCapabilities>,
+  profile: SubscriptionProfile | undefined,
+  inventory: SubscriptionInventory | undefined,
+  agentId: string | undefined,
+  routingMode: RoutingMode = "balanced",
+  routingModifier?: RoutingModifier,
+): string[] {
+  return rankSubscriptionWeightedCandidatesFromPool(
+    category,
+    availableModels,
+    profile,
+    inventory,
+    agentId,
+    routingMode,
+    routingModifier,
+  ).map((item) => item.candidate);
 }

--- a/scripts/__tests__/compare-modifiers.test.mjs
+++ b/scripts/__tests__/compare-modifiers.test.mjs
@@ -1,0 +1,75 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const fixtureDir = join(repoRoot, "scripts", "__fixtures__", "openclaw");
+// Installed tsx binary directly (never `npx` under the release-age cooldown).
+const tsx = join(repoRoot, "node_modules", ".bin", "tsx");
+
+function run(args, input = "") {
+  return spawnSync(tsx, [join("scripts", "compare_modifiers.ts"), ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    input,
+    env: { ...process.env, HOME: "/nonexistent-zeroapi-test-home" },
+  });
+}
+
+test("compare_modifiers emits JSON covering all three modifiers for each prompt", () => {
+  const r = run([
+    "--prompt", "refactor auth module",
+    "--prompt", "hello there",
+    "--openclaw-dir", fixtureDir,
+    "--json",
+  ]);
+  assert.equal(r.status, 0, r.stderr);
+  const data = JSON.parse(r.stdout);
+  assert.equal(data.promptCount, 2);
+  assert.deepEqual(
+    Object.keys(data.summary).sort(),
+    ["coding-aware", "research-aware", "speed-aware"],
+  );
+  for (const modifier of Object.keys(data.summary)) {
+    assert.equal(data.summary[modifier].total, 2);
+  }
+  const refactor = data.prompts.find((p) => p.prompt === "refactor auth module");
+  assert.equal(refactor.balanced.action, "route");
+  assert.equal(refactor.balanced.selectedModel, "openai-codex/gpt-5.4");
+  assert.equal(refactor.variants.length, 3);
+});
+
+test("compare_modifiers renders the report header and per-modifier delta lines in text mode", () => {
+  const r = run(["--prompt", "refactor auth module", "--openclaw-dir", fixtureDir]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /# ZeroAPI Modifier Comparison/);
+  assert.match(r.stdout, /Prompts: 1/);
+  assert.match(r.stdout, /## Delta Vs Balanced/);
+  assert.match(r.stdout, /coding-aware: \d+\/1 changed/);
+});
+
+test("compare_modifiers fails cleanly on a missing config", () => {
+  const r = run(["--prompt", "hi", "--openclaw-dir", join(repoRoot, "scripts", "__fixtures__", "does-not-exist")]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Could not load valid zeroapi-config\.json/);
+});
+
+test("compare_modifiers fails when no prompts are provided", () => {
+  const r = run(["--openclaw-dir", fixtureDir], "");
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /No prompts provided/);
+});
+
+test("compare_modifiers rejects unknown arguments", () => {
+  const r = run(["--bogus"], "");
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Unknown argument: --bogus/);
+});
+
+test("compare_modifiers --help exits 0 and prints usage", () => {
+  const r = run(["--help"], "");
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /--prompts-file/);
+});

--- a/scripts/__tests__/eval.test.mjs
+++ b/scripts/__tests__/eval.test.mjs
@@ -1,0 +1,79 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseLine,
+  counter,
+  pct,
+  pad,
+  padNum,
+  sortedEntries,
+} from "../eval-lib.mjs";
+
+test("parseLine parses a full routing-log line", () => {
+  assert.deepEqual(
+    parseLine(
+      "2026-04-01T10:00:00Z agent=claude category=coding model=zai/glm-5.1 modifier=coding-aware risk=low reason=keyword:refactor",
+    ),
+    {
+      ts: "2026-04-01T10:00:00Z",
+      agent: "claude",
+      category: "coding",
+      model: "zai/glm-5.1",
+      modifier: "coding-aware",
+      risk: "low",
+      reason: "keyword:refactor",
+    },
+  );
+});
+
+test("parseLine applies field defaults when optional fields are absent", () => {
+  assert.deepEqual(parseLine("2026-04-01T10:00:00Z category=default"), {
+    ts: "2026-04-01T10:00:00Z",
+    agent: "unknown",
+    category: "default",
+    model: "default",
+    modifier: "none",
+    risk: "low",
+    reason: "unknown",
+  });
+});
+
+test("parseLine returns null for blank lines and lines without a category", () => {
+  assert.equal(parseLine(""), null);
+  assert.equal(parseLine("   \t  "), null);
+  assert.equal(parseLine("2026-04-01T10:00:00Z agent=claude model=zai/glm-5.1"), null);
+});
+
+test("parseLine captures the full trailing reason, including spaces", () => {
+  const entry = parseLine("2026-04-01T10:00:00Z category=code reason=keyword:fix the auth bug");
+  assert.equal(entry.reason, "keyword:fix the auth bug");
+});
+
+test("counter tallies occurrences", () => {
+  assert.deepEqual(counter(["a", "a", "b"]), { a: 2, b: 1 });
+  assert.deepEqual(counter([]), {});
+});
+
+test("pct formats one-decimal percentages and guards divide-by-zero", () => {
+  assert.equal(pct(0, 0), "0%");
+  assert.equal(pct(1, 4), "25.0%");
+  assert.equal(pct(1, 3), "33.3%");
+});
+
+test("pad right-pads without truncating", () => {
+  assert.equal(pad("ab", 5), "ab   ");
+  assert.equal(pad("abcdef", 3), "abcdef");
+});
+
+test("padNum left-pads numbers without truncating", () => {
+  assert.equal(padNum(7, 4), "   7");
+  assert.equal(padNum(12345, 3), "12345");
+});
+
+test("sortedEntries orders by count descending", () => {
+  assert.deepEqual(sortedEntries({ a: 1, b: 3, c: 2 }), [
+    ["b", 3],
+    ["c", 2],
+    ["a", 1],
+  ]);
+});

--- a/scripts/__tests__/refresh-benchmarks.test.mjs
+++ b/scripts/__tests__/refresh-benchmarks.test.mjs
@@ -77,6 +77,34 @@ assert module.read_key(argparse.Namespace(api_key_file=None)) == "env-key"
 `, [root]);
 });
 
+test("refresh_benchmarks sources benchmark_categories from --output, falling back safely", () => {
+  const root = mkdtempSync(join(tmpdir(), "zeroapi-benchmark-cats-"));
+  runPython(`
+import importlib.util
+import json
+import pathlib
+import sys
+
+script_path = pathlib.Path(sys.argv[1])
+work_dir = pathlib.Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("refresh_benchmarks", script_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+# When the --output target exists, its benchmark_categories must be the source
+# (not the hardcoded repo snapshot).
+output_path = work_dir / "custom.json"
+output_path.write_text(json.dumps({"benchmark_categories": {"marker": "from-output"}}), encoding="utf-8")
+assert module.read_existing_benchmark_categories(output_path) == {"marker": "from-output"}
+
+# When neither the --output target nor the default exists, degrade to None
+# instead of raising FileNotFoundError (first run to a brand-new path).
+missing_output = work_dir / "does-not-exist.json"
+missing_default = work_dir / "no-default.json"
+assert module.read_existing_benchmark_categories(missing_output, missing_default) is None
+`, [root]);
+});
+
 test("refresh_benchmarks writes benchmarks with atomic replace semantics", () => {
   const root = mkdtempSync(join(tmpdir(), "zeroapi-benchmark-write-"));
   runPython(`

--- a/scripts/__tests__/simulate.test.mjs
+++ b/scripts/__tests__/simulate.test.mjs
@@ -1,0 +1,78 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const fixtureDir = join(repoRoot, "scripts", "__fixtures__", "openclaw");
+// Use the installed tsx binary directly (never `npx`, which would touch the
+// registry under the global minimum-release-age cooldown).
+const tsx = join(repoRoot, "node_modules", ".bin", "tsx");
+const fixtureVersion = JSON.parse(
+  readFileSync(join(fixtureDir, "zeroapi-config.json"), "utf-8"),
+).version;
+
+function run(args, input) {
+  return spawnSync(tsx, [join("scripts", "simulate.ts"), ...args], {
+    cwd: repoRoot,
+    encoding: "utf-8",
+    input,
+    // A real ~/.openclaw must never leak in: every test passes --openclaw-dir.
+    env: { ...process.env, HOME: "/nonexistent-zeroapi-test-home" },
+  });
+}
+
+test("simulate routes a coding prompt deterministically against the fixture", () => {
+  const r = run(["--prompt", "refactor auth module", "--current-model", "zai/glm-5.1", "--openclaw-dir", fixtureDir]);
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Action: route/);
+  assert.match(r.stdout, /Reason: keyword:refactor/);
+  assert.match(r.stdout, /Category: code/);
+  assert.match(r.stdout, /Selected model: openai-codex\/gpt-5\.4/);
+  assert.match(r.stdout, /Summary: Routed to openai-codex\/gpt-5\.4 .* under coding-aware\./);
+});
+
+test("simulate emits valid JSON carrying the config version and resolution fields", () => {
+  const r = run(["--prompt", "refactor auth module", "--current-model", "zai/glm-5.1", "--openclaw-dir", fixtureDir, "--json"]);
+  assert.equal(r.status, 0, r.stderr);
+  const parsed = JSON.parse(r.stdout);
+  assert.equal(parsed.configVersion, fixtureVersion);
+  assert.equal(parsed.action, "route");
+  assert.equal(parsed.selectedModel, "openai-codex/gpt-5.4");
+  // includeDiagnostics is always on in the simulator, so the frontier is exposed.
+  assert.ok(Array.isArray(parsed.frontier) && parsed.frontier.length > 0);
+  assert.equal(parsed.frontier[0].candidate, parsed.selectedModel);
+});
+
+test("simulate reads the prompt from stdin when --prompt is omitted", () => {
+  const r = run(["--openclaw-dir", fixtureDir], "refactor auth module\n");
+  assert.equal(r.status, 0, r.stderr);
+  assert.match(r.stdout, /Prompt: refactor auth module/);
+  assert.match(r.stdout, /Action: route/);
+});
+
+test("simulate exits non-zero with a clear error when the config is missing", () => {
+  const r = run(["--prompt", "hi", "--openclaw-dir", join(repoRoot, "scripts", "__fixtures__", "does-not-exist")]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Could not load valid zeroapi-config\.json/);
+});
+
+test("simulate exits non-zero when no prompt is provided via flag or stdin", () => {
+  const r = run(["--openclaw-dir", fixtureDir], "");
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /No prompt provided/);
+});
+
+test("simulate rejects unknown arguments", () => {
+  const r = run(["--bogus"], "");
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /Unknown argument: --bogus/);
+});
+
+test("simulate --help exits 0 and prints usage", () => {
+  const r = run(["--help"], "");
+  assert.equal(r.status, 0);
+  assert.match(r.stdout, /Usage:/);
+});

--- a/scripts/eval-lib.mjs
+++ b/scripts/eval-lib.mjs
@@ -1,0 +1,95 @@
+/**
+ * Pure, IO-free helpers for the ZeroAPI routing-log evaluator (scripts/eval.ts).
+ *
+ * Extracted into a side-effect-free module so they can be unit-tested directly,
+ * mirroring scripts/managed-install-lib.mjs. The main report pipeline (file read,
+ * argv parsing, stdout, process.exit) stays in eval.ts and imports these.
+ *
+ * @typedef {{ ts: string, agent: string, category: string, model: string,
+ *   modifier: string, risk: string, reason: string }} LogEntry
+ */
+
+/**
+ * Parse a single routing-log line into a structured entry, or null when the line
+ * lacks the minimum required fields (timestamp + category).
+ * @param {string} line
+ * @returns {LogEntry | null}
+ */
+export function parseLine(line) {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  const tsMatch = trimmed.match(/^(\S+)/);
+  const agentMatch = trimmed.match(/agent=(\S+)/);
+  const catMatch = trimmed.match(/category=(\S+)/);
+  const modelMatch = trimmed.match(/model=(\S+)/);
+  const modifierMatch = trimmed.match(/modifier=(\S+)/);
+  const riskMatch = trimmed.match(/risk=(\S+)/);
+  const reasonMatch = trimmed.match(/reason=(.+)$/);
+
+  if (!tsMatch || !catMatch) return null;
+
+  return {
+    ts: tsMatch[1],
+    agent: agentMatch?.[1] ?? "unknown",
+    category: catMatch[1],
+    model: modelMatch?.[1] ?? "default",
+    modifier: modifierMatch?.[1] ?? "none",
+    risk: riskMatch?.[1] ?? "low",
+    reason: reasonMatch?.[1] ?? "unknown",
+  };
+}
+
+/**
+ * Frequency map of the given values.
+ * @param {string[]} arr
+ * @returns {Record<string, number>}
+ */
+export function counter(arr) {
+  const counts = {};
+  for (const item of arr) {
+    counts[item] = (counts[item] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Percentage string with one decimal, or "0%" when the total is zero.
+ * @param {number} n
+ * @param {number} total
+ * @returns {string}
+ */
+export function pct(n, total) {
+  if (total === 0) return "0%";
+  return `${((n / total) * 100).toFixed(1)}%`;
+}
+
+/**
+ * Right-pad a string to a fixed width (no truncation when already wider).
+ * @param {string} s
+ * @param {number} width
+ * @returns {string}
+ */
+export function pad(s, width) {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+/**
+ * Left-pad a number to a fixed width (no truncation when already wider).
+ * @param {number} n
+ * @param {number} width
+ * @returns {string}
+ */
+export function padNum(n, width) {
+  const s = String(n);
+  return s.length >= width ? s : " ".repeat(width - s.length) + s;
+}
+
+/**
+ * Entries of a count map sorted by count, descending.
+ * @param {Record<string, number>} obj
+ * @returns {[string, number][]}
+ */
+export function sortedEntries(obj) {
+  return Object.entries(obj).sort((a, b) => b[1] - a[1]);
+}

--- a/scripts/eval.ts
+++ b/scripts/eval.ts
@@ -17,6 +17,7 @@
 
 import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { parseLine, counter, pct, pad, padNum, sortedEntries } from "./eval-lib.mjs";
 
 const HOME = process.env.HOME ?? "/root";
 const LOG_PATH = join(HOME, ".openclaw", "logs", "zeroapi-routing.log");
@@ -30,57 +31,6 @@ type LogEntry = {
   risk: string;
   reason: string;
 };
-
-function parseLine(line: string): LogEntry | null {
-  const trimmed = line.trim();
-  if (!trimmed) return null;
-
-  const tsMatch = trimmed.match(/^(\S+)/);
-  const agentMatch = trimmed.match(/agent=(\S+)/);
-  const catMatch = trimmed.match(/category=(\S+)/);
-  const modelMatch = trimmed.match(/model=(\S+)/);
-  const modifierMatch = trimmed.match(/modifier=(\S+)/);
-  const riskMatch = trimmed.match(/risk=(\S+)/);
-  const reasonMatch = trimmed.match(/reason=(.+)$/);
-
-  if (!tsMatch || !catMatch) return null;
-
-  return {
-    ts: tsMatch[1],
-    agent: agentMatch?.[1] ?? "unknown",
-    category: catMatch[1],
-    model: modelMatch?.[1] ?? "default",
-    modifier: modifierMatch?.[1] ?? "none",
-    risk: riskMatch?.[1] ?? "low",
-    reason: reasonMatch?.[1] ?? "unknown",
-  };
-}
-
-function counter(arr: string[]): Record<string, number> {
-  const counts: Record<string, number> = {};
-  for (const item of arr) {
-    counts[item] = (counts[item] ?? 0) + 1;
-  }
-  return counts;
-}
-
-function pct(n: number, total: number): string {
-  if (total === 0) return "0%";
-  return `${((n / total) * 100).toFixed(1)}%`;
-}
-
-function pad(s: string, width: number): string {
-  return s.length >= width ? s : s + " ".repeat(width - s.length);
-}
-
-function padNum(n: number, width: number): string {
-  const s = String(n);
-  return s.length >= width ? s : " ".repeat(width - s.length) + s;
-}
-
-function sortedEntries(obj: Record<string, number>): [string, number][] {
-  return Object.entries(obj).sort((a, b) => b[1] - a[1]);
-}
 
 // --- main ---
 
@@ -106,7 +56,7 @@ if (lastN) {
   lines = lines.slice(-lastN);
 }
 
-let entries = lines.map(parseLine).filter((e): e is LogEntry => e !== null);
+let entries: LogEntry[] = lines.map(parseLine).filter((e: unknown): e is LogEntry => e !== null);
 
 if (sinceDate) {
   entries = entries.filter((e) => e.ts >= sinceDate!);

--- a/scripts/refresh_benchmarks.py
+++ b/scripts/refresh_benchmarks.py
@@ -197,6 +197,24 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def read_existing_benchmark_categories(
+    output_path: Path,
+    default_path: Path = DEFAULT_OUTPUT,
+) -> Any:
+    """Source the round-tripped ``benchmark_categories`` block.
+
+    Prefer the file actually being refreshed (``--output``) so a custom target is
+    both the source and the destination; fall back to the canonical repo snapshot,
+    and degrade to ``None`` when neither file exists (e.g. a first run writing to a
+    brand-new ``--output`` path) instead of raising ``FileNotFoundError``.
+    """
+    source = output_path if output_path.exists() else default_path
+    try:
+        return json.loads(source.read_text()).get("benchmark_categories")
+    except FileNotFoundError:
+        return None
+
+
 def main() -> None:
     parser = build_parser()
     args = parser.parse_args()
@@ -208,7 +226,8 @@ def main() -> None:
     policy_families, policy_slug_map = load_policy_families()
     models = transform_models(response.get("data") or [], policy_slug_map)
 
-    benchmark_categories = json.loads(DEFAULT_OUTPUT.read_text()).get("benchmark_categories")
+    output_path = Path(args.output)
+    benchmark_categories = read_existing_benchmark_categories(output_path)
     policy_family_included_count = sum(
         1 for model in models if model.get("policy_family", {}).get("included")
     )


### PR DESCRIPTION
## Summary

Executes the remaining quality follow-ups surfaced by the post-merge review of PR #20/#21. Each item was first verified to be a *real* issue by a per-item investigation (one read-only agent each), then fixed, tested, and finally re-checked by a 5-area adversarial review (all clean). Nothing here touches the `router.py` routing contract, so **TS↔Python parity is structurally unaffected** (the committed `test_parity.py` stays green at 9/9).

One candidate from the list — the `subscription-advisory` "watcher not cleaned up on stop()" item — was investigated and found to be a **non-issue**: `stop()` already clears the debounce timer, closes every watcher, and guards double-stop, and all handles are `unref`'d. Capturing the handle in `index.ts` would add dead state with no dispose hook to consume it, so it was deliberately not changed.

## Fixes (real bugs / robustness)

- **`cron-apply` paired by array position** → could patch the wrong cron job's payload if a caller filtered/reordered the jobs array between audit and apply. Now pairs each report item to its job by stable id (`normalizeString(job.id) ?? "(unknown)"`, mirroring `cron-audit` `buildItemBase`), with a same-id queue so duplicates still map 1:1 in order.
- **`agent-audit` hint inference used first-match on a joined `id+name+description` haystack** → an agent whose id encodes its role (e.g. `monitor`, `ops-*`) was mis-hinted by incidental words ("content", "deploy"). Now prefers the pattern matched by the id, falling back to the haystack only when the id carries no recognized token.
- **`vision_aux.py` used an absolute `from router import`** → crashed with `ModuleNotFoundError` when loaded as a package submodule (`hermes.vision_aux`). Now package-relative with a script fallback; works both ways.
- **`refresh_benchmarks.py` always read `benchmark_categories` from the hardcoded repo `benchmarks.json`** → ignored `--output` and crashed with `FileNotFoundError` when the default snapshot was absent. Now sources from the `--output` target with a safe fallback. **Default runs are byte-identical.**

## Added

- **Frontier diagnostic on the vision-capability-escape route.** Image turns now expose the same per-candidate frontier detail as normal routes — via a new `rankSubscriptionWeightedCandidatesFromPool`, computed **only under `includeDiagnostics`** so the runtime image path still pays nothing (the <1ms zero-LLM guarantee is preserved). Parity-neutral: the Python adapter exposes no frontier field.
- **Test coverage for previously-untested dev tooling:** `eval.ts` (pure helpers extracted to a side-effect-free `eval-lib.mjs` and unit-tested), plus subprocess regression tests for `simulate.ts` and `compare_modifiers.ts` against the committed fixture. Regression tests added for cron id-pairing, agent-audit id-priority, the `vision_aux` package import, and `refresh_benchmarks --output` sourcing.

## CI hardening

- **SHA-pin every first-party action** (`actions/checkout@…v5.0.1`, `actions/setup-node@…v5.0.0`, `actions/setup-python@…v6.2.0`) across all four workflows — a moved/compromised major tag could otherwise run unreviewed code on jobs holding `GITHUB_TOKEN`/`contents:write`. SHAs resolved live from the canonical action repos.
- **Add a `github-actions` Dependabot config** so those pins are bumped forward automatically (closes the "pinning freezes security patches" gap).
- **Add explicit `timeout-minutes` to every job** so a hung step can't run to the 6h default (publish uses 60 to cover its 10×300s+15s install-retry loop).
- `OPENCLAW_VERIFY_VERSION` is **intentionally left `latest`** — it's a post-publish smoke test that must validate against the OpenClaw users have now, not a frozen binary.

## Verification

```
npm run audit  → exit 0
  release:check → ZeroAPI release preflight ok for 3.8.36
  test:plugin   → 212 passed (22 files)
  test:scripts  → 48 passed
  test:hermes   → 72 passed (7 groups; test_parity 9/9 OK)
  git diff --check → clean
```

- Adversarial review: 5 independent reviewers (plugin logic, frontier refactor, Python, scripts/tests, CI) → **all `clean`, zero defects**.
- `eval.ts` smoke-run confirmed identical output after the helper extraction.
- The 2 pre-existing untracked files (`plugin/package-lock.json`, `references/mahmory-autoresearch-usage.md`) are preserved, never staged.

No version bump (changes recorded under `[Unreleased]`; `release:check` stays green on the existing 3.8.36 needles).
