### PR TITLE
chore(release): 3.8.37

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,8 +15,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      # Pinned to the immutable commit the v2 tag resolves to (v2.3.9) so a moved or
+      # Pinned to an immutable commit SHA (see trailing # vX.Y.Z) so a moved or
       # compromised tag cannot run unreviewed code on the secret-scanning job.
+      # Bumped forward by the github-actions Dependabot config.
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.8.37] - 2026-06-05
+
 ### Fixed
 - Restore OpenClaw(TS) <-> Hermes(Python) routing parity across five proven divergences
   (verified by a head-to-head harness, now committed as `integrations/hermes/test_parity.py`):

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.8.36
+version: 3.8.37
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when the user mentions model routing, multi-model setup, "which model should I use",
@@ -13,7 +13,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Cu
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.8.36 - Plugin-Based Model Routing
+# ZeroAPI v3.8.37 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -235,7 +235,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.8.36",
+  "version": "3.8.37",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.0.0",

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: zeroapi-router
-version: 3.8.36
+version: 3.8.37
 description: Benchmark-aware model routing for Hermes Agent using ZeroAPI policy config
 provides_hooks:
   - pre_model_route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.8.36",
+  "version": "3.8.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroapi-workspace",
-      "version": "3.8.36",
+      "version": "3.8.37",
       "workspaces": [
         "plugin"
       ],
@@ -1221,7 +1221,7 @@
     },
     "plugin": {
       "name": "zeroapi",
-      "version": "3.8.36",
+      "version": "3.8.37",
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.8.36",
+  "version": "3.8.37",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -10,7 +10,7 @@ import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 import { readPreviousCategory, recordRouteCategory } from "./route-state.js";
 import type { TaskCategory } from "./types.js";
 
-const PLUGIN_VERSION = "3.8.36";
+const PLUGIN_VERSION = "3.8.37";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Transparent subscription-aware model and account routing for OpenClaw",
-  "version": "3.8.36",
+  "version": "3.8.37",
   "activation": {
     "onStartup": true
   },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.8.36",
+  "version": "3.8.37",
   "private": true,
   "description": "ZeroAPI - transparent subscription-aware model and account routing for OpenClaw",
   "type": "module",

--- a/plugin/skills/zeroapi/SKILL.md
+++ b/plugin/skills/zeroapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.8.36
+version: 3.8.37
 description: Configure the ZeroAPI OpenClaw plugin for subscription-aware model routing. Use when the user runs /zeroapi, asks to set up model routing, pastes the ZeroAPI repo URL, or asks what the repo does or whether it would help.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}


### PR DESCRIPTION
## Summary

Cuts **3.8.37** from the accumulated `[Unreleased]` work, and folds in a small CI comment fix from the Dependabot action bump that just merged.

### What's in 3.8.37
- **Parity (PR #20):** restored OpenClaw(TS) ↔ Hermes(Python) routing parity across five proven divergences, with a committed head-to-head `test_parity.py`.
- **Review follow-ups (PR #21):** three further parity gaps (R1/R2/R3) + the NUL-byte/`.gitattributes` fix + route-state perf.
- **Quality follow-ups (PR #22):** cron-apply id-keyed pairing, agent-audit id-priority hinting, `vision_aux` package import, `refresh_benchmarks --output` sourcing, vision-escape frontier diagnostic, test coverage for `eval`/`simulate`/`compare_modifiers`, and CI hardening (SHA-pinned actions + Dependabot + job timeouts).

### Also here
- `ci`: made the gitleaks pin comment version-agnostic — Dependabot bumped `gitleaks-action` to v3.0.0 (CI-validated for this public repo) but left the comment referencing the old v2.3.9 pin.

## Version bump
All needles 3.8.36 → 3.8.37: `package.json`, `plugin/package.json`, `plugin/openclaw.plugin.json`, `package-lock.json` (root + plugin workspace), `SKILL.md` (×3), `plugin/skills/zeroapi/SKILL.md`, `plugin/index.ts`, `integrations/hermes/plugin.yaml`, and the dated `CHANGELOG` entry.

## Verification
```
npm run audit → exit 0
  release:check  → ZeroAPI release preflight ok for 3.8.37
  test:plugin    → 212 passed (22 files)
  test:scripts   → 48 passed
  test:hermes    → 72 passed (7 groups; test_parity 9/9)
  git diff --check → clean
```

No behavior change beyond what is already on `main`. On merge, tagging `v3.8.37` + a GitHub Release triggers the ClawHub publish workflow.
