### PR TITLE
chore(release): prepare v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-07-11
+
 ### Added
 - Refresh the July 2026 starter model pool for GPT-5.6 Sol/Terra/Luna, GLM-5.2, Kimi K2.7 Code/K2.6, MiniMax M3, Qwen Portal 3.5 Plus, Grok 4.5, and Grok Build 0.1 with explicit benchmark-proxy metadata where direct rows are unavailable.
 - Add issue #29 subscription catalog contract coverage for filtering, active-versus-excluded xAI surfaces, excluded providers, Anthropic/Google exclusion, legacy Qwen migration, and unknown-provider fail-closed behavior.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.5.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.8.37-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.8.37)
+[![Version](https://img.shields.io/badge/version-3.9.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.9.0)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 
@@ -158,7 +158,7 @@ ZeroAPI is a source-linked ClawHub package. Before installing from ClawHub, veri
 - source path: `plugin`
 - source tag or commit: matches the GitHub release you intend to install
 
-Prefer exact version installs such as `clawhub:zeroapi@3.8.37` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
+Prefer exact version installs such as `clawhub:zeroapi@3.9.0` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
 
 ZeroAPI does not require shell-piped installer commands. The GitHub release workflow publishes the ClawHub package from `plugin/`, verifies ClawHub latest/exact-version metadata, and runs an OpenClaw install smoke test before treating the release as published.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.8.37
+version: 3.9.0
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when the user mentions model routing, multi-model setup, "which model should I use",
@@ -13,7 +13,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Cu
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.8.37 - Plugin-Based Model Routing
+# ZeroAPI v3.9.0 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -235,7 +235,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.1.0",

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-05",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/subscription-profile.json
+++ b/examples/subscription-profile.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: zeroapi-router
-version: 3.8.37
+version: 3.9.0
 description: Benchmark-aware model routing for Hermes Agent using ZeroAPI policy config
 provides_hooks:
   - pre_model_route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.8.37",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroapi-workspace",
-      "version": "3.8.37",
+      "version": "3.9.0",
       "workspaces": [
         "plugin"
       ],
@@ -1221,7 +1221,7 @@
     },
     "plugin": {
       "name": "zeroapi",
-      "version": "3.8.37",
+      "version": "3.9.0",
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.8.37",
+  "version": "3.9.0",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -55,7 +55,7 @@ The advisory file and logs can still be used for operators who do not want chann
 Install only from the source-linked package:
 
 ```bash
-openclaw plugins install clawhub:zeroapi@3.8.37
+openclaw plugins install clawhub:zeroapi@3.9.0
 ```
 
 Verify the package source points to:

--- a/plugin/benchmarks.json
+++ b/plugin/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.37",
+  "version": "3.9.0",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-05",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -10,7 +10,7 @@ import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 import { readPreviousCategory, recordRouteCategory } from "./route-state.js";
 import type { TaskCategory } from "./types.js";
 
-const PLUGIN_VERSION = "3.8.37";
+const PLUGIN_VERSION = "3.9.0";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Transparent subscription-aware model and account routing for OpenClaw",
-  "version": "3.8.37",
+  "version": "3.9.0",
   "activation": {
     "onStartup": true
   },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.8.37",
+  "version": "3.9.0",
   "private": true,
   "description": "ZeroAPI - transparent subscription-aware model and account routing for OpenClaw",
   "type": "module",

--- a/plugin/skills/zeroapi/SKILL.md
+++ b/plugin/skills/zeroapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.8.37
+version: 3.9.0
 description: Configure the ZeroAPI OpenClaw plugin for subscription-aware model routing. Use when the user runs /zeroapi, asks to set up model routing, pastes the ZeroAPI repo URL, or asks what the repo does or whether it would help.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}

--- a/scripts/__tests__/release-preflight.test.mjs
+++ b/scripts/__tests__/release-preflight.test.mjs
@@ -27,6 +27,12 @@ const PREFLIGHT_INPUTS = [
   "scripts/refresh_benchmarks.py",
   "benchmarks.json",
   "plugin/benchmarks.json",
+  "examples/openai-only.json",
+  "examples/subscription-profile.json",
+  "examples/openai-multi-account.json",
+  "examples/openai-glm.json",
+  "examples/openai-glm-kimi.json",
+  "examples/full-stack.json",
 ];
 
 function runPreflight(cwd) {
@@ -78,7 +84,9 @@ test("release_preflight passes on a minimal aligned fixture (no full-repo copy)"
 test("release_preflight catches benchmark snapshot drift", () => {
   const tmp = buildAlignedFixture();
   try {
-    writeFileSync(join(tmp, "plugin", "benchmarks.json"), "{}\n");
+    const pluginSnapshot = JSON.parse(readFileSync(join(tmp, "plugin", "benchmarks.json"), "utf8"));
+    pluginSnapshot.source = "intentional parity drift";
+    writeFileSync(join(tmp, "plugin", "benchmarks.json"), `${JSON.stringify(pluginSnapshot, null, 2)}\n`);
     assert.throws(
       () => runPreflight(tmp),
       (error) => `${error.stdout ?? ""}${error.stderr ?? ""}`.includes("benchmark snapshots must be byte-identical"),

--- a/scripts/release_preflight.mjs
+++ b/scripts/release_preflight.mjs
@@ -28,6 +28,7 @@ const version = rootPackage.version;
 assert(version, "root package.json has no version");
 assert(pluginPackage.version === version, `plugin/package.json version ${pluginPackage.version} does not match ${version}`);
 assert(manifest.version === version, `plugin manifest version ${manifest.version} does not match ${version}`);
+assert(lockfile.version === version, "package-lock top-level version is not aligned");
 assert(lockfile.packages?.[""]?.version === version, "package-lock root version is not aligned");
 assert(lockfile.packages?.plugin?.version === version, "package-lock plugin workspace version is not aligned");
 assert(manifest.activation?.onStartup === true, "plugin manifest must keep activation.onStartup=true");
@@ -47,6 +48,20 @@ const versionNeedles = [
 ];
 for (const [path, needle] of versionNeedles) {
   assert(readText(join(repoRoot, path)).includes(needle), `${path} is missing ${needle}`);
+}
+
+const versionedJsonSurfaces = [
+  "benchmarks.json",
+  "plugin/benchmarks.json",
+  "examples/openai-only.json",
+  "examples/subscription-profile.json",
+  "examples/openai-multi-account.json",
+  "examples/openai-glm.json",
+  "examples/openai-glm-kimi.json",
+  "examples/full-stack.json",
+];
+for (const path of versionedJsonSurfaces) {
+  assert(readJson(join(repoRoot, path)).version === version, `${path} version is not aligned with ${version}`);
 }
 
 const stageScript = readText(join(repoRoot, "scripts", "stage_clawhub_plugin.mjs"));


### PR DESCRIPTION
## Summary

Prepare ZeroAPI `v3.9.0` after the July 2026 model/provider refresh merged in #33.

- align package, lockfile, OpenClaw, Hermes, skill, README and generated-example versions
- release the current Unreleased changelog as `3.9.0` dated 2026-07-11
- align byte-identical benchmark snapshot versions
- strengthen release preflight coverage for lockfile, benchmarks and generated examples
- keep historical `3.8.37` and compatibility fixture references intact

## Validation

- `npm run examples:refresh` twice; second run clean
- `npm run release:check`
- `npm run audit:ci`
- plugin: 243 passed
- scripts: 68 passed
- Hermes: 93 passed
- production dependency audit: 0 vulnerabilities
- root/plugin benchmark byte parity
- all committed JSON parsed
- public/privacy hygiene scan clean

## Safety

This PR prepares release metadata only. It does **not** create a tag, publish a GitHub release, dispatch ClawHub publication, or modify local runtime configuration.
