### PR TITLE
fix(hermes): canonicalize provider aliases and fail closed on collisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.9.1] - 2026-07-11
+
+### Fixed
+- Treat provider-catalog aliases as the same current model for Hermes capability, external-pool, specialist-agent, and selected/current comparisons without rewriting configured model or routing-rule keys.
+
 ## [3.9.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.5.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.9.0-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.9.0)
+[![Version](https://img.shields.io/badge/version-3.9.1-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.9.1)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 
@@ -158,7 +158,7 @@ ZeroAPI is a source-linked ClawHub package. Before installing from ClawHub, veri
 - source path: `plugin`
 - source tag or commit: matches the GitHub release you intend to install
 
-Prefer exact version installs such as `clawhub:zeroapi@3.9.0` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
+Prefer exact version installs such as `clawhub:zeroapi@3.9.1` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
 
 ZeroAPI does not require shell-piped installer commands. The GitHub release workflow publishes the ClawHub package from `plugin/`, verifies ClawHub latest/exact-version metadata, and runs an OpenClaw install smoke test before treating the release as published.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.9.0
+version: 3.9.1
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when the user mentions model routing, multi-model setup, "which model should I use",
@@ -13,7 +13,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Cu
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.9.0 - Plugin-Based Model Routing
+# ZeroAPI v3.9.1 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -235,7 +235,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.1.0",

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-05",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/subscription-profile.json
+++ b/examples/subscription-profile.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: zeroapi-router
-version: 3.9.0
+version: 3.9.1
 description: Benchmark-aware model routing for Hermes Agent using ZeroAPI policy config
 provides_hooks:
   - pre_model_route

--- a/integrations/hermes/router.py
+++ b/integrations/hermes/router.py
@@ -414,6 +414,14 @@ def _canonical_provider(provider: str) -> str:
     return provider
 
 
+def _comparison_model_ref(model_ref: str) -> str:
+    """Canonicalize provider aliases only for ephemeral model identity checks."""
+    if "/" not in model_ref:
+        return model_ref
+    provider, model = model_ref.split("/", 1)
+    return f"{_canonical_provider(provider)}/{model}"
+
+
 def _disabled_provider_list(config: Config) -> list[str]:
     disabled: list[str] = []
     seen: set[str] = set()
@@ -1016,7 +1024,11 @@ class ZeroAPIRouter:
         if agent_id and workspace_hints is None and agent_id in workspace_hints_by_agent:
             return None
 
-        if agent_id and workspace_hints is None and current_model and current_model != self.config.get("default_model"):
+        if (
+            agent_id and workspace_hints is None and current_model
+            and _comparison_model_ref(current_model)
+            != _comparison_model_ref(self.config.get("default_model", ""))
+        ):
             return None
 
         if trigger in {"cron", "heartbeat"}:
@@ -1049,11 +1061,17 @@ class ZeroAPIRouter:
         # override the default-category stay and route to a vision-capable model.
         current = current_model or self.config.get("default_model")
         models = self.config.get("models", {})
+        comparison_models = {
+            _comparison_model_ref(model_key): (model_key, capabilities)
+            for model_key, capabilities in models.items()
+        }
+        current_identity = _comparison_model_ref(current) if isinstance(current, str) else None
         modifier = self.config.get("routing_modifier")
         modifier = modifier if isinstance(modifier, str) else None
 
         if category == "default" and likely_vision and current:
-            current_caps = models.get(current)
+            current_entry = comparison_models.get(current_identity) if current_identity else None
+            current_caps = current_entry[1] if current_entry else None
             if isinstance(current_caps, dict) and not current_caps.get("supports_vision", False):
                 vision_capable = []
                 for model_key, caps in models.items():
@@ -1068,7 +1086,7 @@ class ZeroAPIRouter:
                     if not ordered:
                         ordered = vision_capable
                     target = ordered[0] if ordered else vision_capable[0]
-                    if target != current:
+                    if _comparison_model_ref(target) != current_identity:
                         provider = _provider_id(target)
                         return {
                             "provider": _hermes_provider(provider, self.config),
@@ -1082,7 +1100,7 @@ class ZeroAPIRouter:
         if (
             isinstance(current, str)
             and current
-            and current not in models
+            and current_identity not in comparison_models
             and self.config.get("external_model_policy", "stay") != "allow"
         ):
             return None
@@ -1139,7 +1157,7 @@ class ZeroAPIRouter:
         _sort_ranked(ranked, modifier, category)
 
         selected = ranked[0]["model_key"]
-        if selected == current:
+        if _comparison_model_ref(selected) == current_identity:
             return None
 
         provider = _provider_id(selected)

--- a/integrations/hermes/router.py
+++ b/integrations/hermes/router.py
@@ -1061,10 +1061,15 @@ class ZeroAPIRouter:
         # override the default-category stay and route to a vision-capable model.
         current = current_model or self.config.get("default_model")
         models = self.config.get("models", {})
-        comparison_models = {
-            _comparison_model_ref(model_key): (model_key, capabilities)
-            for model_key, capabilities in models.items()
-        }
+        comparison_models: dict[str, tuple[str, Any]] = {}
+        for model_key, capabilities in models.items():
+            identity = _comparison_model_ref(model_key)
+            # Alias-equivalent configured keys are ambiguous even when their
+            # capability records currently match. Reject the entire route
+            # deterministically rather than selecting by insertion order.
+            if identity in comparison_models:
+                return None
+            comparison_models[identity] = (model_key, capabilities)
         current_identity = _comparison_model_ref(current) if isinstance(current, str) else None
         modifier = self.config.get("routing_modifier")
         modifier = modifier if isinstance(modifier, str) else None

--- a/integrations/hermes/test_adapter.py
+++ b/integrations/hermes/test_adapter.py
@@ -25,6 +25,29 @@ adapter = _load_adapter()
 
 
 class HermesAdapterPayloadTest(unittest.TestCase):
+    def test_actual_codex_payload_matches_openai_config_and_routes(self):
+        caps = {"context_window": 100000, "supports_vision": False, "speed_tps": 50,
+                "ttft_seconds": 1, "benchmarks": {"coding": 90, "intelligence": 90}}
+        config = {
+            "version": "test", "default_model": "openai/gpt-5.6-sol",
+            "external_model_policy": "stay",
+            "models": {"openai/gpt-5.6-sol": caps, "openai/gpt-5.6-luna": caps},
+            "routing_rules": {"code": {"primary": "openai/gpt-5.6-luna", "fallbacks": []}},
+            "keywords": {"code": ["implement"]}, "high_risk_keywords": [],
+            "subscription_profile": {"global": {"openai-codex": {"enabled": True, "tierId": "pro"}}},
+        }
+        with tempfile.TemporaryDirectory(prefix="zeroapi-adapter-alias-") as temp_dir:
+            path = Path(temp_dir) / "zeroapi-config.json"
+            path.write_text(json.dumps(config), encoding="utf-8")
+            adapter._router = None
+            with patch.dict(os.environ, {"ZEROAPI_CONFIG_PATH": str(path)}, clear=False):
+                route = adapter._pre_model_route(
+                    user_message="implement this", provider="openai-codex", model="gpt-5.6-sol",
+                )
+            self.assertIsNotNone(route)
+            assert route is not None
+            self.assertEqual((route["provider"], route["model"]), ("openai-codex", "gpt-5.6-luna"))
+
     def test_malformed_only_config_keeps_router_unset(self):
         malformed = {
             "version": "test", "default_model": "qwen/model", "models": {},

--- a/integrations/hermes/test_router.py
+++ b/integrations/hermes/test_router.py
@@ -442,6 +442,37 @@ class ZeroAPIHermesRouterTest(unittest.TestCase):
             "implement this feature", current_model="kimi/synthetic-model",
         ))
 
+    def test_alias_collision_with_conflicting_capabilities_fails_closed_in_both_orders(self):
+        blind = copy.deepcopy(CONFIG["models"]["openai-codex/gpt-5.4"])
+        sighted = copy.deepcopy(blind)
+        sighted["supports_vision"] = True
+        for entries in (
+            [("openai/gpt-collision", blind), ("openai-codex/gpt-collision", sighted)],
+            [("openai-codex/gpt-collision", sighted), ("openai/gpt-collision", blind)],
+        ):
+            with self.subTest(order=[key for key, _ in entries]):
+                config = copy.deepcopy(CONFIG)
+                config["models"] = dict([*entries, ("moonshot/kimi-k2.5", CONFIG["models"]["moonshot/kimi-k2.5"])])
+                config["default_model"] = entries[0][0]
+                config["routing_rules"]["default"] = {"primary": "moonshot/kimi-k2.5", "fallbacks": []}
+                self.assertIsNone(ZeroAPIRouter(config).resolve(
+                    "inspect this screenshot", current_model="openai/gpt-collision",
+                ))
+
+    def test_identical_alias_duplicate_is_rejected_not_silently_deduplicated(self):
+        # Duplicate canonical identities are invalid even when capability records
+        # currently match; rejecting them prevents later edits becoming ambiguous.
+        capabilities = copy.deepcopy(CONFIG["models"]["openai-codex/gpt-5.4"])
+        config = copy.deepcopy(CONFIG)
+        config["models"] = {
+            "openai/gpt-collision": capabilities,
+            "openai-codex/gpt-collision": copy.deepcopy(capabilities),
+        }
+        config["routing_rules"]["code"] = {"primary": "openai/gpt-collision", "fallbacks": []}
+        self.assertIsNone(ZeroAPIRouter(config).resolve(
+            "implement this feature", current_model="openai/gpt-collision",
+        ))
+
     def test_skips_explicit_specialist_agent(self):
         config = {**CONFIG, "workspace_hints": {"codex": None}}
         route = ZeroAPIRouter(config).resolve(

--- a/integrations/hermes/test_router.py
+++ b/integrations/hermes/test_router.py
@@ -410,6 +410,38 @@ class ZeroAPIHermesRouterTest(unittest.TestCase):
         )
         self.assertIsNone(route)
 
+    def test_alias_equivalent_current_is_in_pool_and_routes_to_deterministic_target(self):
+        config = copy.deepcopy(CONFIG)
+        sol = copy.deepcopy(config["models"]["openai-codex/gpt-5.4"])
+        luna = copy.deepcopy(sol)
+        luna["benchmarks"]["coding"] = 99
+        config["default_model"] = "openai/gpt-5.6-sol"
+        config["models"] = {"openai/gpt-5.6-sol": sol, "openai/gpt-5.6-luna": luna}
+        config["routing_rules"]["code"] = {
+            "primary": "openai/gpt-5.6-luna", "fallbacks": ["openai/gpt-5.6-sol"],
+        }
+        route = ZeroAPIRouter(config).resolve(
+            "implement this feature", current_model="openai-codex/gpt-5.6-sol",
+        )
+        self.assertIsNotNone(route)
+        self.assertEqual((route["provider"], route["model"]), ("openai-codex", "gpt-5.6-luna"))
+
+    def test_alias_equivalent_selected_model_does_not_redundantly_switch(self):
+        config = copy.deepcopy(CONFIG)
+        config["models"] = {"openai/gpt-5.4": config["models"]["openai-codex/gpt-5.4"]}
+        config["routing_rules"]["code"] = {"primary": "openai/gpt-5.4", "fallbacks": []}
+        self.assertIsNone(ZeroAPIRouter(config).resolve(
+            "implement this feature", current_model="openai-codex/gpt-5.4",
+        ))
+
+    def test_non_openai_catalog_alias_uses_same_comparison_identity(self):
+        config = copy.deepcopy(CONFIG)
+        config["models"] = {"moonshot/synthetic-model": config["models"]["moonshot/kimi-k2.5"]}
+        config["routing_rules"]["code"] = {"primary": "moonshot/synthetic-model", "fallbacks": []}
+        self.assertIsNone(ZeroAPIRouter(config).resolve(
+            "implement this feature", current_model="kimi/synthetic-model",
+        ))
+
     def test_skips_explicit_specialist_agent(self):
         config = {**CONFIG, "workspace_hints": {"codex": None}}
         route = ZeroAPIRouter(config).resolve(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroapi-workspace",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "workspaces": [
         "plugin"
       ],
@@ -1221,7 +1221,7 @@
     },
     "plugin": {
       "name": "zeroapi",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -55,7 +55,7 @@ The advisory file and logs can still be used for operators who do not want chann
 Install only from the source-linked package:
 
 ```bash
-openclaw plugins install clawhub:zeroapi@3.9.0
+openclaw plugins install clawhub:zeroapi@3.9.1
 ```
 
 Verify the package source points to:

--- a/plugin/benchmarks.json
+++ b/plugin/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.0",
+  "version": "3.9.1",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-05",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -10,7 +10,7 @@ import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 import { readPreviousCategory, recordRouteCategory } from "./route-state.js";
 import type { TaskCategory } from "./types.js";
 
-const PLUGIN_VERSION = "3.9.0";
+const PLUGIN_VERSION = "3.9.1";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Transparent subscription-aware model and account routing for OpenClaw",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "activation": {
     "onStartup": true
   },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "private": true,
   "description": "ZeroAPI - transparent subscription-aware model and account routing for OpenClaw",
   "type": "module",

--- a/plugin/skills/zeroapi/SKILL.md
+++ b/plugin/skills/zeroapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.9.0
+version: 3.9.1
 description: Configure the ZeroAPI OpenClaw plugin for subscription-aware model routing. Use when the user runs /zeroapi, asks to set up model routing, pastes the ZeroAPI repo URL, or asks what the repo does or whether it would help.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}


### PR DESCRIPTION
## Summary
- canonicalize provider-alias model references before comparison
- fail closed on duplicate canonical identities instead of selecting by insertion order
- preserve external-model stay behavior and configured route keys
- add Hermes adapter/router regression coverage
- synchronize v3.9.1 release metadata and changelog

## Validation
- full npm and Hermes suites pass
- release preflight passes
- npm audit: 0 vulnerabilities
- Codex final review: MERGE_READY / NO_REMAINING_ISSUES

The Hermes doctor redesign is intentionally excluded and remains a separate design track.