### PR TITLE
fix: preserve Kimi code route across benchmark refreshes

### DIFF
--- a/plugin/__tests__/decision.test.ts
+++ b/plugin/__tests__/decision.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { resolveRoutingDecision } from "../decision.js";
+import { buildStarterConfig } from "../onboarding.js";
 import type { ZeroAPIConfig } from "../types.js";
 
 const config: ZeroAPIConfig = {
@@ -84,6 +85,21 @@ const config: ZeroAPIConfig = {
 };
 
 describe("resolveRoutingDecision", () => {
+  it("preserves the Kimi code route after subscription-weighted runtime ranking", () => {
+    const kimiConfig = buildStarterConfig({
+      providers: [{ providerId: "moonshot", tierId: "moderato" }],
+    });
+    const result = resolveRoutingDecision(kimiConfig, {
+      prompt: "implement a function and add tests",
+      currentModel: kimiConfig.default_model,
+    });
+
+    expect(kimiConfig.default_model).toBe("moonshot/kimi-k2.6");
+    expect(result.weightedCandidates[0]).toBe("moonshot/kimi-k2.7-code");
+    expect(result.action).toBe("route");
+    expect(result.selectedModel).toBe("moonshot/kimi-k2.7-code");
+  });
+
   it("skips specialist agents before classification", () => {
     const result = resolveRoutingDecision(config, {
       prompt: "refactor the worker queue",

--- a/plugin/onboarding.ts
+++ b/plugin/onboarding.ts
@@ -351,13 +351,26 @@ function preferKimiGeneralDefault(candidates: string[]): string[] {
   return [generalModel, ...candidates.filter((candidate) => candidate !== generalModel)];
 }
 
+function preferKimiCodeDefault(candidates: string[]): string[] {
+  const codeModel = "moonshot/kimi-k2.7-code";
+  const generalModel = "moonshot/kimi-k2.6";
+  if (candidates[0] !== generalModel || !candidates.includes(codeModel)) {
+    return candidates;
+  }
+  return [codeModel, ...candidates.filter((candidate) => candidate !== codeModel)];
+}
+
 function buildRoutingRules(models: Record<string, ModelCapabilities>): Record<string, RoutingRule> {
   const categories: TaskCategory[] = ["code", "research", "orchestration", "math", "fast", "default"];
   const rules: Record<string, RoutingRule> = {};
 
   for (const category of categories) {
     const scored = sortModelsForCategory(category, models);
-    const ranked = category === "default" ? preferKimiGeneralDefault(scored) : scored;
+    const ranked = category === "default"
+      ? preferKimiGeneralDefault(scored)
+      : category === "code"
+        ? preferKimiCodeDefault(scored)
+        : scored;
     rules[category] = {
       primary: ranked[0],
       fallbacks: ranked.slice(1),

--- a/plugin/router.ts
+++ b/plugin/router.ts
@@ -337,6 +337,20 @@ export function rankSubscriptionWeightedCandidates(
     return a.originalIndex - b.originalIndex;
   });
 
+  if (category === "code" && ranked[0]?.candidate === "moonshot/kimi-k2.6") {
+    const codeIndex = ranked.findIndex((item) => item.candidate === "moonshot/kimi-k2.7-code");
+    const codeCandidate = ranked[codeIndex];
+    if (
+      codeCandidate
+      && codeCandidate.withinFrontier
+      && ranked[0].withinFrontier
+      && codeCandidate.effectivePressureScore === ranked[0].effectivePressureScore
+    ) {
+      ranked.splice(codeIndex, 1);
+      ranked.unshift(codeCandidate);
+    }
+  }
+
   return ranked.map((item) => ({
     candidate: item.candidate,
     benchmarkStrength: item.benchmarkStrength,


### PR DESCRIPTION
## Summary
- keep `moonshot/kimi-k2.7-code` as the code-category primary when Kimi is the leading candidate pair
- keep `moonshot/kimi-k2.6` as the general/default primary
- avoid overriding unrelated providers that outrank Kimi

## Why
A benchmark snapshot refresh raised Kimi K2.6 slightly above Kimi K2.7 Code for the code category, violating the starter-routing contract introduced in #33 and breaking main CI after #36 merged.

## Verification
- focused onboarding tests: 18/18 PASS
- `npm run audit:ci`: PASS
- `git diff --check`: PASS