### PR TITLE
Fix #35: Make the Hermes test command discover test files automatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "npm run test:plugin && npm run test:scripts && npm run test:hermes",
     "test:plugin": "npm --workspace zeroapi test",
     "test:scripts": "node --test scripts/__tests__/*.test.mjs",
-    "test:hermes": "python3 integrations/hermes/test_router.py && python3 integrations/hermes/test_parity.py && python3 integrations/hermes/test_adapter.py && python3 integrations/hermes/test_auth_audit.py && python3 integrations/hermes/test_vision_aux.py && python3 integrations/hermes/test_doctor.py && python3 integrations/hermes/test_runtime_patch.py",
+    "test:hermes": "python3 -m unittest discover -s integrations/hermes -p 'test_*.py'",
     "simulate": "tsx scripts/simulate.ts",
     "eval": "tsx scripts/eval.ts",
     "compare:modifiers": "tsx scripts/compare_modifiers.ts",


### PR DESCRIPTION
## Summary

Implements #35 with a focused maintenance-loop change.

## Verification

- PASS: `git diff --check`
- PASS: `npm test -- --runInBand`

## Risk

No merge/deploy/release is performed by the loop. Maintainer approval is required before merge.

Closes #35