### PR TITLE
chore(release): prepare v3.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## [3.9.3] - 2026-07-20
+
+### Changed
+- Refresh the Artificial Analysis benchmark snapshot to the 2026-07-19 dataset across the root and packaged plugin copies.
+
 ## [3.9.2] - 2026-07-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml/badge.svg)](https://github.com/dorukardahan/ZeroAPI/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenClaw](https://img.shields.io/badge/OpenClaw-2026.5.2+-blue)](https://openclaw.ai)
-[![Version](https://img.shields.io/badge/version-3.9.2-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.9.2)
+[![Version](https://img.shields.io/badge/version-3.9.3-green)](https://github.com/dorukardahan/ZeroAPI/releases/tag/v3.9.3)
 
 **Your AI subscriptions. One plugin. Routing policy that improves with data.**
 
@@ -158,7 +158,7 @@ ZeroAPI is a source-linked ClawHub package. Before installing from ClawHub, veri
 - source path: `plugin`
 - source tag or commit: matches the GitHub release you intend to install
 
-Prefer exact version installs such as `clawhub:zeroapi@3.9.2` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
+Prefer exact version installs such as `clawhub:zeroapi@3.9.3` instead of an unpinned `latest` install. Do not install mirror packages, standalone skills, or similarly named packages that do not link back to this repository.
 
 ZeroAPI does not require shell-piped installer commands. The GitHub release workflow publishes the ClawHub package from `plugin/`, verifies ClawHub latest/exact-version metadata, and runs an OpenClaw install smoke test before treating the release as published.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.9.2
+version: 3.9.3
 description: >
   Route tasks to the best AI model across paid subscriptions via OpenClaw gateway plugin.
   Use when the user mentions model routing, multi-model setup, "which model should I use",
@@ -13,7 +13,7 @@ compatibility: Requires OpenClaw 2026.4.2+ with at least one AI subscription. Cu
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}
 ---
 
-# ZeroAPI v3.9.2 - Plugin-Based Model Routing
+# ZeroAPI v3.9.3 - Plugin-Based Model Routing
 
 You are configuring an OpenClaw **gateway plugin**. ZeroAPI routes **eligible** messages at runtime through the `before_model_resolve` hook. You do **not** route messages manually. Your job is to inspect the user's setup, generate `zeroapi-config.json`, align `openclaw.json`, install/update the plugin, and verify the result.
 
@@ -235,7 +235,7 @@ Required config shape:
 
 ```json
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "<ISO timestamp>",
   "benchmarks_date": "<fetched date>",
   "subscription_catalog_version": "1.1.0",

--- a/benchmarks.json
+++ b/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-19",

--- a/examples/full-stack.json
+++ b/examples/full-stack.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm-kimi.json
+++ b/examples/openai-glm-kimi.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-glm.json
+++ b/examples/openai-glm.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-multi-account.json
+++ b/examples/openai-multi-account.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/openai-only.json
+++ b/examples/openai-only.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/examples/subscription-profile.json
+++ b/examples/subscription-profile.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "generated": "2026-07-05T00:00:00.000Z",
   "benchmarks_date": "2026-07-05",
   "subscription_catalog_version": "1.1.0",

--- a/integrations/hermes/plugin.yaml
+++ b/integrations/hermes/plugin.yaml
@@ -1,5 +1,5 @@
 name: zeroapi-router
-version: 3.9.2
+version: 3.9.3
 description: Benchmark-aware model routing for Hermes Agent using ZeroAPI policy config
 provides_hooks:
   - pre_model_route

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeroapi-workspace",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "workspaces": [
         "plugin"
       ],
@@ -1221,7 +1221,7 @@
     },
     "plugin": {
       "name": "zeroapi",
-      "version": "3.9.2",
+      "version": "3.9.3",
       "devDependencies": {
         "typescript": "^5.7.0",
         "vitest": "^3.2.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi-workspace",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "private": true,
   "description": "Benchmark-driven model routing for OpenClaw",
   "type": "module",

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -55,7 +55,7 @@ The advisory file and logs can still be used for operators who do not want chann
 Install only from the source-linked package:
 
 ```bash
-openclaw plugins install clawhub:zeroapi@3.9.2
+openclaw plugins install clawhub:zeroapi@3.9.3
 ```
 
 Verify the package source points to:

--- a/plugin/benchmarks.json
+++ b/plugin/benchmarks.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.9.2",
+  "version": "3.9.3",
   "source": "Artificial Analysis Data API v2",
   "api": "https://artificialanalysis.ai/api/v2/data/llms/models",
   "fetched": "2026-07-19",

--- a/plugin/index.ts
+++ b/plugin/index.ts
@@ -10,7 +10,7 @@ import { maybePrefixChannelAdvisory } from "./advisory-delivery.js";
 import { readPreviousCategory, recordRouteCategory } from "./route-state.js";
 import type { TaskCategory } from "./types.js";
 
-const PLUGIN_VERSION = "3.9.2";
+const PLUGIN_VERSION = "3.9.3";
 const REGISTER_STATE_KEY = Symbol.for("zeroapi-router.register-state");
 
 type RegisterState = {

--- a/plugin/openclaw.plugin.json
+++ b/plugin/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "id": "zeroapi-router",
   "name": "ZeroAPI Router",
   "description": "Transparent subscription-aware model and account routing for OpenClaw",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "activation": {
     "onStartup": true
   },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeroapi",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "private": true,
   "description": "ZeroAPI - transparent subscription-aware model and account routing for OpenClaw",
   "type": "module",

--- a/plugin/skills/zeroapi/SKILL.md
+++ b/plugin/skills/zeroapi/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeroapi
-version: 3.9.2
+version: 3.9.3
 description: Configure the ZeroAPI OpenClaw plugin for subscription-aware model routing. Use when the user runs /zeroapi, asks to set up model routing, pastes the ZeroAPI repo URL, or asks what the repo does or whether it would help.
 user-invocable: true
 metadata: {"openclaw":{"emoji":"⚡","category":"routing","os":["darwin","linux"],"requires":{"anyBins":["openclaw"],"config":["agents"]}}}


### PR DESCRIPTION
## Summary

- prepare ZeroAPI v3.9.3 from the current `main` benchmark refresh
- synchronize the workspace, plugin, Hermes adapter, examples, docs, and packaged benchmark version surfaces
- add curated release notes for the 2026-07-19 Artificial Analysis snapshot

This release is scoped to commits already on `main`; existing open PRs are intentionally excluded.

## Verification

- `npm run audit:ci`
- plugin: 244 tests passed
- scripts: 69 tests passed
- Hermes adapter: 99 tests passed
- `npm audit --omit=dev` — 0 production vulnerabilities
- release preflight, snapshot parity, `git diff --check`, and added-line privacy scan passed

Release prep only: this PR does not publish a GitHub release or ClawHub package.
